### PR TITLE
Feature/rework lan browser

### DIFF
--- a/src/core/common.rs
+++ b/src/core/common.rs
@@ -1,6 +1,4 @@
 use std::fmt::Display;
-
-use log::debug;
 use reqwest::{header::{HeaderMap, HeaderValue}, Client };
 use serde::{Deserialize, Serialize};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{command, Parser, Subcommand};
-use flexi_logger::{FileSpec, ModuleFilter};
+use flexi_logger::FileSpec;
 use log::{error, info};
 use mappers::Mapper;
 use core::{authenticator, configuration::{get_configuration, Configuration}, discovery, prometheus::{self}};


### PR DESCRIPTION
implements #40 

Example of new output:
``` text
# HELP fbx_exporter_lan_browser_device device, 1 for active
# TYPE fbx_exporter_lan_browser_device gauge
fbx_exporter_lan_browser_device{id="ether-aa:bb:cc:dd:ee:ff",iface="pub",l2ident_id="aa:bb:cc:dd:ee:ff",l2ident_type="mac_address",primary_name="Cisco",primary_name_manual="false",type="networking_device",vendor_name="Cisco"} 1
fbx_exporter_lan_browser_device{id="ether-00:11:22:33:44:55",iface="pub",l2ident_id="00:11:22:33:44:55",l2ident_type="mac_address",primary_name="ffffffff-0000-1111-2222-444444444444",primary_name_manual="false",type="smartphone",vendor_name="Electronic Technology Company Limited"} 0
# HELP fbx_exporter_lan_browser_device_l3_connectivity device l3 connectivity, 1 for active
# TYPE fbx_exporter_lan_browser_device_l3_connectivity gauge
fbx_exporter_lan_browser_device_l3_connectivity{addr="192.168.1.1",af="ipv4",ident="aa:bb:cc:dd:ee:ff",iface="pub",name="Cisco"} 1
fbx_exporter_lan_browser_device_l3_connectivity{addr="192.168.1.20",af="ipv4",ident="00:11:22:33:44:55",iface="pub",name="ffffffff-0000-1111-2222-444444444444"} 0
fbx_exporter_lan_browser_device_l3_connectivity{addr="192.168.1.10",af="ipv4",ident="aa:bb:cc:dd:ee:ff",iface="pub",name="Cisco"} 0
fbx_exporter_lan_browser_device_l3_connectivity{addr="2a01:e0a:460:f6b0:bd04:eb69:b6a1:5a43",af="ipv6",ident="00:11:22:33:44:55",iface="pub",name="ffffffff-0000-1111-2222-444444444444"} 0
fbx_exporter_lan_browser_device_l3_connectivity{addr="2a01:e0a:460:f6b0:c1a7:8fad:f975:61be",af="ipv6",ident="00:11:22:33:44:55",iface="pub",name="ffffffff-0000-1111-2222-444444444444"} 0
fbx_exporter_lan_browser_device_l3_connectivity{addr="2a01:e0a:460:f6b0:fd3c:2568:1bdf:e357",af="ipv6",ident="00:11:22:33:44:55",iface="pub",name="ffffffff-0000-1111-2222-444444444444"} 0
fbx_exporter_lan_browser_device_l3_connectivity{addr="fe80::65fa:8fb9:5a70:ef63",af="ipv6",ident="00:11:22:33:44:55",iface="pub",name="ffffffff-0000-1111-2222-444444444444"} 0
fbx_exporter_lan_browser_device_l3_connectivity{addr="fe80::d69e:3bff:fe80:db16",af="ipv6",ident="00:11:22:33:44:55",iface="pub",name="ffffffff-0000-1111-2222-444444444444"} 0
# HELP fbx_exporter_lan_browser_device_last_activity device last activity timestamp
# TYPE fbx_exporter_lan_browser_device_last_activity gauge
fbx_exporter_lan_browser_device_last_activity{iface="pub",name="ffffffff-0000-1111-2222-444444444444"} 1724230989
fbx_exporter_lan_browser_device_last_activity{iface="pub",name="Cisco"} 1724234757
# HELP fbx_exporter_lan_browser_device_name device name
# TYPE fbx_exporter_lan_browser_device_name gauge
fbx_exporter_lan_browser_device_name{ident="aa:bb:cc:dd:ee:ff",iface="pub",name="Cisco",source="dhcp"} 1
fbx_exporter_lan_browser_device_name{ident="aa:bb:cc:dd:ee:ff",iface="pub",name="wlan-router",source="mdns"} 1
fbx_exporter_lan_browser_device_name{ident="00:11:22:33:44:55",iface="pub",name="ffffffff-0000-1111-2222-444444444444",source="mdns"} 1
# HELP fbx_exporter_lan_browser_iface_hosts network interfaces
# TYPE fbx_exporter_lan_browser_iface_hosts gauge
fbx_exporter_lan_browser_iface_hosts{name="pub"} 5
fbx_exporter_lan_browser_iface_hosts{name="wifiguest"} 0
```
