### PR TITLE
add switch api

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You will find [here](https://grafana.com/grafana/dashboards/21637) a Grafana boa
   * &#10060; LCD: 0%
   * &#10060; Network Share: 0%
   * &#10060; UPnP AV: 0%
-  * &#10060; Switch: 0%
+  * &#9989; Switch: **100%**
   * &#10060; Wi-Fi: 0%
   * &#9989; System: **100%**
   * &#10060; VPN Server: 0%

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ connection = true
 lan = true
 # Exposes lan browser, this option does not work in bridge_mode
 lan_browser = true
+# Exposes switch, this option may not work properly in bridge_mode
+switch = true
 # Exposes settings
 settings = true
 # Exposes contacts
@@ -226,3 +228,8 @@ curl http://localhost:9102/metrics
 ## Support this project
 
 If you want to help, you can contribute or you can still [buy me a coffee](https://buymeacoffee.com/shackerd) or leave a star!
+
+## Useful links
+
+* [https://dev.freebox.fr/blog](https://dev.freebox.fr/blog) : official Freebox blog
+* [https://dev.freebox.fr/bugs](https://dev.freebox.fr/bugs) : official Freebox bugs report board

--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,8 @@ connection = true
 lan = true
 # Exposes lan browser, this option does not work in bridge_mode
 lan_browser = true
+# Exposes switch, this option may not work properly in bridge_mode
+switch = true
 # Exposes settings
 system = true
 # Exposes contacts

--- a/src/core/configuration.rs
+++ b/src/core/configuration.rs
@@ -28,6 +28,7 @@ pub struct MetricsConfiguration {
     pub system: Option<bool>,
     pub lan: Option<bool>,
     pub lan_browser: Option<bool>,
+    pub switch: Option<bool>,
     pub contacts: Option<bool>,
     pub calls: Option<bool>,
     pub explorer: Option<bool>,
@@ -128,6 +129,7 @@ refresh = 5
 connection = true
 lan = true
 lan_browser = true
+switch = true
 system = false
 contacts = true
 calls = true
@@ -167,6 +169,7 @@ retention = 31";
         assert_eq!(true, conf.metrics.connection.unwrap());
         assert_eq!(true, conf.metrics.lan.unwrap());
         assert_eq!(true, conf.metrics.lan_browser.unwrap());
+        assert_eq!(true, conf.metrics.switch.unwrap());
         assert_eq!(false, conf.metrics.system.unwrap());
         assert_eq!(true, conf.metrics.contacts.unwrap());
         assert_eq!(true, conf.metrics.calls.unwrap());
@@ -192,7 +195,7 @@ retention = 31";
                 calls: None, connection: None, contacts: None,
                 downloader: None, explorer: None, parental: None,
                 pvr: None, system: None, prefix: None, lan_browser: None,
-                lan: None
+                lan: None, switch: None
             }
         };
 
@@ -204,7 +207,7 @@ retention = 31";
                 calls: None, connection: None, contacts: None,
                 downloader: None, explorer: None, parental: None,
                 pvr: None, system: None, prefix: None,lan_browser: None,
-                lan: None
+                lan: None, switch: None
             }
         };
 
@@ -216,7 +219,7 @@ retention = 31";
                 calls: None, connection: None, contacts: None,
                 downloader: None, explorer: None, parental: None,
                 pvr: None, system: None, prefix: None, lan_browser: None,
-                lan: None
+                lan: None, switch: None
             }
         };
 
@@ -236,7 +239,7 @@ retention = 31";
                 calls: None, connection: None, contacts: None,
                 downloader: None, explorer: None, parental: None,
                 pvr: None, system: None, prefix: None, lan_browser: None,
-                lan: None
+                lan: None, switch: None
             }
         };
 
@@ -248,7 +251,7 @@ retention = 31";
                 calls: None, connection: None, contacts: None,
                 downloader: None, explorer: None, parental: None,
                 pvr: None, system: None, prefix: Some(" ".to_string()),
-                lan_browser: None, lan: None
+                lan_browser: None, lan: None, switch: None
             }
         };
 
@@ -260,7 +263,7 @@ retention = 31";
                 calls: None, connection: None, contacts: None,
                 downloader: None, explorer: None, parental: None,
                 pvr: None, system: None, prefix: Some("fbx_exporter".to_string()),
-                lan_browser: None, lan: None
+                lan_browser: None, lan: None, switch: None
             }
         };
 

--- a/src/mappers/mod.rs
+++ b/src/mappers/mod.rs
@@ -3,6 +3,7 @@ use connection::ConnectionMetricMap;
 use system::SystemMetricMap;
 use lanbrowser::LanBrowserMetricMap;
 use lan::LanMetricMap;
+use switch::SwitchMetricMap;
 use log::{error, warn};
 
 use crate::core::{common::AuthenticatedHttpClientFactory, configuration::{ApiConfiguration, MetricsConfiguration}};
@@ -11,6 +12,7 @@ pub mod connection;
 pub mod system;
 pub mod lan;
 pub mod lanbrowser;
+pub mod switch;
 
 #[async_trait]
 pub trait MetricMap {
@@ -28,26 +30,30 @@ impl Mapper {
         let mut maps: Vec<Box<dyn MetricMap>> = vec![];
 
         if conf.connection.unwrap() {
-            maps.push(Box::new(ConnectionMetricMap::new(factory.clone(), conf.prefix.clone().unwrap())));
+            maps.push(Box::new(ConnectionMetricMap::new(factory.to_owned(), conf.prefix.to_owned().unwrap())));
         }
         if conf.system.unwrap() {
-            maps.push(Box::new(SystemMetricMap::new(factory.clone(), conf.prefix.clone().unwrap())));
+            maps.push(Box::new(SystemMetricMap::new(factory.to_owned(), conf.prefix.to_owned().unwrap())));
         }
 
         if conf.lan.unwrap() {
-            maps.push(Box::new(LanMetricMap::new(factory.clone(), conf.prefix.clone().unwrap())));
+            maps.push(Box::new(LanMetricMap::new(factory.to_owned(), conf.prefix.to_owned().unwrap())));
         }
 
         if conf.lan_browser.unwrap() {
 
             let mode = api_conf.mode.unwrap_or_default();
             if mode == "router" {
-                let lan_browser_map = LanBrowserMetricMap::new(factory.clone(), conf.prefix.clone().unwrap());
+                let lan_browser_map = LanBrowserMetricMap::new(factory.to_owned(), conf.prefix.to_owned().unwrap());
                 maps.push(Box::new(lan_browser_map));
             }
             else {
                 warn!("lan_browser is incompatible with this freebox mode ({}), the option has been disabled", mode);
             }
+        }
+
+        if conf.switch.unwrap() {
+            maps.push(Box::new(SwitchMetricMap::new(factory.to_owned(), conf.prefix.to_owned().unwrap())));
         }
 
 

--- a/src/mappers/switch.rs
+++ b/src/mappers/switch.rs
@@ -1,0 +1,246 @@
+use async_trait::async_trait;
+use log::debug;
+use prometheus_exporter::prometheus::{register_int_gauge_vec, IntGaugeVec};
+use serde::Deserialize;
+
+use crate::core::common::{AuthenticatedHttpClientFactory, FreeboxResponse, FreeboxResponseError};
+
+use super::MetricMap;
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct SwitchPortStatus {
+    id: Option<i16>,
+    link: Option<String>,
+    speed: Option<String>,
+    mac_list: Option<Vec<SwitchPortHost>>
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct SwitchPortStats {
+    rx_packets_rate: Option<i64>,
+    rx_good_bytes: Option<i64>,
+    rx_oversize_packets: Option<i64>,
+    rx_unicast_packets: Option<i64>,
+    tx_bytes_rate: Option<i64>,
+    tx_unicast_packets: Option<i64>,
+    rx_bytes_rate: Option<i64>,
+    tx_packets: Option<i64>,
+    tx_collisions: Option<i64>,
+    tx_packets_rate: Option<i64>,
+    tx_fcs: Option<i64>,
+    tx_bytes: Option<i64>,
+    rx_jabber_packets: Option<i64>,
+    tx_single: Option<i64>,
+    tx_excessive: Option<i64>,
+    rx_pause: Option<i64>,
+    rx_multicast_packets: Option<i64>,
+    tx_pause: Option<i64>,
+    rx_good_packets: Option<i64>,
+    rx_broadcast_packets: Option<i64>,
+    tx_multiple: Option<i64>,
+    tx_deferred: Option<i64>,
+    tx_late: Option<i64>,
+    tx_multicast_packets: Option<i64>,
+    rx_fcs_packets: Option<i64>,
+    tx_broadcast_packets: Option<i64>,
+    rx_err_packets: Option<i64>,
+    rx_fragments_packets: Option<i64>,
+    rx_bad_bytes: Option<i64>,
+    rx_undersize_packets: Option<i64>
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct SwitchPortHost {
+    mac: Option<String>,
+    hostname: Option<String>
+}
+
+pub struct SwitchMetricMap {
+    factory: AuthenticatedHttpClientFactory,
+    rx_packets_rate_gauge: IntGaugeVec,
+    rx_good_bytes_gauge: IntGaugeVec,
+    rx_oversize_packets_gauge: IntGaugeVec,
+    rx_unicast_packets_gauge: IntGaugeVec,
+    tx_bytes_rate_gauge: IntGaugeVec,
+    tx_unicast_packets_gauge: IntGaugeVec,
+    rx_bytes_rate_gauge: IntGaugeVec,
+    tx_packets_gauge: IntGaugeVec,
+    tx_collisions_gauge: IntGaugeVec,
+    tx_packets_rate_gauge: IntGaugeVec,
+    tx_fcs_gauge: IntGaugeVec,
+    tx_bytes_gauge: IntGaugeVec,
+    rx_jabber_packets_gauge: IntGaugeVec,
+    tx_single_gauge: IntGaugeVec,
+    tx_excessive_gauge: IntGaugeVec,
+    rx_pause_gauge: IntGaugeVec,
+    rx_multicast_packets_gauge: IntGaugeVec,
+    tx_pause_gauge: IntGaugeVec,
+    rx_good_packets_gauge: IntGaugeVec,
+    rx_broadcast_packets_gauge: IntGaugeVec,
+    tx_multiple_gauge: IntGaugeVec,
+    tx_deferred_gauge: IntGaugeVec,
+    tx_late_gauge: IntGaugeVec,
+    tx_multicast_packets_gauge: IntGaugeVec,
+    rx_fcs_packets_gauge: IntGaugeVec,
+    tx_broadcast_packets_gauge: IntGaugeVec,
+    rx_err_packets_gauge: IntGaugeVec,
+    rx_fragments_packets_gauge: IntGaugeVec,
+    rx_bad_bytes_gauge: IntGaugeVec,
+    rx_undersize_packets_gauge: IntGaugeVec,
+    port_status_gauge: IntGaugeVec,
+    port_speed_gauge: IntGaugeVec,
+    port_mac_list_gauge: IntGaugeVec
+}
+
+impl SwitchMetricMap {
+    pub fn new(factory: AuthenticatedHttpClientFactory, prefix: String) -> Self {
+        let prfx: String = format!("{prefix}_switch");
+        let stats_prfx: String = format!("{prfx}_stats");
+
+        Self {
+            factory,
+            rx_packets_rate_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_packets_rate"), "rx packet rate", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_packet_rate gauge")),
+            rx_good_bytes_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_good_bytes"), "rx good bytes", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_good_bytes gauge")),
+            rx_oversize_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_oversize_packets"), "rx oversize packets", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_oversize_packets gauge")),
+            rx_unicast_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_unicast_packets"), "rx unicast packets", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_unicast_packets gauge")),
+            tx_bytes_rate_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_bytes_rate"), "tx bytes rate", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_bytes_rate gauge")),
+            tx_unicast_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_unicast_packets"), "tx unicast packets", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_unicast_packets gauge")),
+            rx_bytes_rate_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_bytes_rate"), "rx bytes rate", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_bytes_rate gauge")),
+            tx_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_packets"), "tx packets", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_packets gauge")),
+            tx_collisions_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_collisions"), "tx collisions", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_collisions gauge")),
+            tx_packets_rate_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_packets_rate"), "tx packets rate", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_packets_rate gauge")),
+            tx_fcs_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_fcs"), "tx fcs", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_fcs gauge")),
+            tx_bytes_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_bytes"), "tx bytes", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_bytes gauge")),
+            rx_jabber_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_jabber_packets"), "rx jabber packets", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_jabber_packets gauge")),
+            tx_single_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_single"), "tx single", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_single gauge")),
+            tx_excessive_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_excessive"), "tx excessive", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_excessive gauge")),
+            rx_pause_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_pause"), "rx pause", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_pause gauge")),
+            rx_multicast_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_multicast_packets"), "rx multicast packets", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_multicast_packets gauge")),
+            tx_pause_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_pause"), "tx pause", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_pause gauge")),
+            rx_good_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_good_packets"), "tx good packets", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_good_packets gauge")),
+            rx_broadcast_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_broadcast_packets"), "rx broadcast packets", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_broadcast_packets gauge")),
+            tx_multiple_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_multiple"), "tx multiple", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_multiple gauge")),
+            tx_deferred_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_deferred"), "tx deferred", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_deferred gauge")),
+            tx_late_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_late"), "tx late", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_late gauge")),
+            tx_multicast_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_multicast_packets"), "tx multicast packets", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_multicast_packets gauge")),
+            rx_fcs_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_fcs_packets"), "rx fcs packets", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_fcs_packets gauge")),
+            tx_broadcast_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_tx_broadcast_packets"), "tx broadcast packets", &["port"]).expect(&format!("cannot create {stats_prfx}_tx_broadcast_packets gauge")),
+            rx_err_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_err_packets"), "rx err packets", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_err_packets gauge")),
+            rx_fragments_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_fragments_packets"), "rx fragments packets", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_fragments_packets gauge")),
+            rx_bad_bytes_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_bad_bytes"), "rx bad bytes", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_bad_bytes gauge")),
+            rx_undersize_packets_gauge: register_int_gauge_vec!(format!("{stats_prfx}_rx_undersize_packets"), "rx undersize packets", &["port"]).expect(&format!("cannot create {stats_prfx}_rx_undersize_packets gauge")),
+            port_status_gauge: register_int_gauge_vec!(format!("{prfx}_port_status"), "port status, 1 for link up", &["port"]).expect(&format!("cannot create {prfx}_port_status gauge")),
+            port_speed_gauge: register_int_gauge_vec!(format!("{prfx}_port_speed"), "port status speed", &["port"]).expect(&format!("cannot create {prfx}_port_speed gauge")),
+            port_mac_list_gauge: register_int_gauge_vec!(format!("{prfx}_port_mac_list"), "port mac list, always 1", &["port", "mac", "hostname"]).expect(&format!("cannot create {prfx}_port_mac_list gauge")),
+        }
+    }
+
+    async fn get_ports_status(&self) -> Result<Vec<SwitchPortStatus>, Box<dyn std::error::Error>> {
+
+        debug!("fetching switch ports statuses");
+
+        let body =
+            self.factory.create_client().await.unwrap().get(format!("{}v4/switch/status/", self.factory.api_url))
+            .send().await?
+            .text().await?;
+
+        let res = match serde_json::from_str::<FreeboxResponse<Vec<SwitchPortStatus>>>(&body)
+            { Err(e) => return Err(Box::new(e)), Ok(r) => r };
+
+        if !res.success.unwrap_or(false) {
+            return Err(Box::new(FreeboxResponseError::new(res.msg.unwrap_or_default())));
+        }
+
+        let statuses = match res.result
+            { None => return Err(Box::new(FreeboxResponseError::new("v4/switch/status/ response was empty".to_string()))), Some(r) => r};
+
+        Ok(statuses)
+    }
+
+    async fn get_port_stats(&self, port_status: &SwitchPortStatus) -> Result<SwitchPortStats, Box<dyn std::error::Error>> {
+
+        debug!("fetching switch ports stats");
+
+        let port_id = port_status.id.unwrap_or_default();
+
+        let body =
+            self.factory.create_client().await.unwrap().get(format!("{}v4/switch/port/{}/stats", self.factory.api_url, port_id))
+            .send().await?
+            .text().await?;
+
+        let res = match serde_json::from_str::<FreeboxResponse<SwitchPortStats>>(&body)
+            { Err(e) => return Err(Box::new(e)), Ok(r) => r };
+
+        if !res.success.unwrap_or(false) {
+            return Err(Box::new(FreeboxResponseError::new(res.msg.unwrap_or_default())));
+        }
+
+        match res.result {
+            None => return Err(Box::new(FreeboxResponseError::new(format!("v4/switch/port/{}/stats response was empty", port_id)))),
+            Some(r) =>  Ok(r)
+        }
+    }
+
+    async fn set_all(&self) -> Result<(), Box<dyn std::error::Error>> {
+
+        let port_statuses = match self.get_ports_status().await
+            { Err(e) => return Err(e), Ok(r) => r };
+
+        for port_status in port_statuses {
+            let stats = match self.get_port_stats(&port_status).await
+                { Err(e) => return Err(e), Ok(r) => r };
+
+            self.rx_packets_rate_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_packets_rate.unwrap_or_default());
+            self.rx_good_bytes_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_good_bytes.unwrap_or_default());
+            self.rx_oversize_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_oversize_packets.unwrap_or_default());
+            self.rx_unicast_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_unicast_packets.unwrap_or_default());
+            self.tx_bytes_rate_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_bytes_rate.unwrap_or_default());
+            self.tx_unicast_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_unicast_packets.unwrap_or_default());
+            self.rx_bytes_rate_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_bytes_rate.unwrap_or_default());
+            self.tx_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_packets.unwrap_or_default());
+            self.tx_collisions_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_collisions.unwrap_or_default());
+            self.tx_packets_rate_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_packets_rate.unwrap_or_default());
+            self.tx_fcs_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_fcs.unwrap_or_default());
+            self.tx_bytes_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_bytes.unwrap_or_default());
+            self.rx_jabber_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_jabber_packets.unwrap_or_default());
+            self.tx_single_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_single.unwrap_or_default());
+            self.tx_excessive_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_excessive.unwrap_or_default());
+            self.rx_pause_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_pause.unwrap_or_default());
+            self.rx_multicast_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_multicast_packets.unwrap_or_default());
+            self.tx_pause_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_pause.unwrap_or_default());
+            self.rx_good_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_good_packets.unwrap_or_default());
+            self.rx_broadcast_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_broadcast_packets.unwrap_or_default());
+            self.tx_multiple_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_multiple.unwrap_or_default());
+            self.tx_deferred_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_deferred.unwrap_or_default());
+            self.tx_late_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_late.unwrap_or_default());
+            self.tx_multicast_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_multicast_packets.unwrap_or_default());
+            self.rx_fcs_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_fcs_packets.unwrap_or_default());
+            self.tx_broadcast_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.tx_broadcast_packets.unwrap_or_default());
+            self.rx_err_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_err_packets.unwrap_or_default());
+            self.rx_fragments_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_fragments_packets.unwrap_or_default());
+            self.rx_bad_bytes_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_bad_bytes.unwrap_or_default());
+            self.rx_undersize_packets_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(stats.rx_undersize_packets.unwrap_or_default());
+
+            self.port_status_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set((port_status.link.unwrap_or_default() == "up").into());
+            self.port_speed_gauge.with_label_values(&[&port_status.id.unwrap_or_default().to_string()]).set(i64::from_str_radix(&port_status.speed.unwrap_or("0".to_string()), 10).unwrap());
+
+            for host in port_status.mac_list.to_owned().unwrap_or_default() {
+                self.port_mac_list_gauge.with_label_values(
+                    &[&port_status.id.unwrap_or_default().to_string(), &host.mac.unwrap_or_default(), &host.hostname.unwrap_or_default()]
+                ).set(1);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl MetricMap for SwitchMetricMap {
+
+    async fn init(&mut self) -> Result<(), Box<dyn std::error::Error>> { Ok(()) }
+
+    async fn set(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        match self.set_all().await { Err(e) => return Err(e), _ => {} };
+        Ok(())
+    }
+}


### PR DESCRIPTION
adds switch API

example output:

``` text
# HELP fbx_exporter_switch_port_mac_list port mac list, always 1
# TYPE fbx_exporter_switch_port_mac_list gauge
fbx_exporter_switch_port_mac_list{hostname="Cisco",mac="00:11:22:33:44",port="3"} 1
# HELP fbx_exporter_switch_port_speed port status speed
# TYPE fbx_exporter_switch_port_speed gauge
fbx_exporter_switch_port_speed{port="1"} 10
fbx_exporter_switch_port_speed{port="2"} 10
fbx_exporter_switch_port_speed{port="3"} 1000
# HELP fbx_exporter_switch_port_status port status, 1 for link up
# TYPE fbx_exporter_switch_port_status gauge
fbx_exporter_switch_port_status{port="1"} 0
fbx_exporter_switch_port_status{port="2"} 0
fbx_exporter_switch_port_status{port="3"} 1
# HELP fbx_exporter_switch_stats_rx_bad_bytes rx bad bytes
# TYPE fbx_exporter_switch_stats_rx_bad_bytes gauge
fbx_exporter_switch_stats_rx_bad_bytes{port="1"} 0
fbx_exporter_switch_stats_rx_bad_bytes{port="2"} 0
fbx_exporter_switch_stats_rx_bad_bytes{port="3"} 0
# HELP fbx_exporter_switch_stats_rx_broadcast_packets rx broadcast packets
# TYPE fbx_exporter_switch_stats_rx_broadcast_packets gauge
fbx_exporter_switch_stats_rx_broadcast_packets{port="1"} 0
fbx_exporter_switch_stats_rx_broadcast_packets{port="2"} 8556
fbx_exporter_switch_stats_rx_broadcast_packets{port="3"} 20336
# HELP fbx_exporter_switch_stats_rx_bytes_rate rx bytes rate
# TYPE fbx_exporter_switch_stats_rx_bytes_rate gauge
fbx_exporter_switch_stats_rx_bytes_rate{port="1"} 0
fbx_exporter_switch_stats_rx_bytes_rate{port="2"} 0
fbx_exporter_switch_stats_rx_bytes_rate{port="3"} 2784
# HELP fbx_exporter_switch_stats_rx_err_packets rx err packets
# TYPE fbx_exporter_switch_stats_rx_err_packets gauge
fbx_exporter_switch_stats_rx_err_packets{port="1"} 0
fbx_exporter_switch_stats_rx_err_packets{port="2"} 0
fbx_exporter_switch_stats_rx_err_packets{port="3"} 0
# HELP fbx_exporter_switch_stats_rx_fcs_packets rx fcs packets
# TYPE fbx_exporter_switch_stats_rx_fcs_packets gauge
fbx_exporter_switch_stats_rx_fcs_packets{port="1"} 0
fbx_exporter_switch_stats_rx_fcs_packets{port="2"} 0
fbx_exporter_switch_stats_rx_fcs_packets{port="3"} 0
# HELP fbx_exporter_switch_stats_rx_fragments_packets rx fragments packets
# TYPE fbx_exporter_switch_stats_rx_fragments_packets gauge
fbx_exporter_switch_stats_rx_fragments_packets{port="1"} 0
fbx_exporter_switch_stats_rx_fragments_packets{port="2"} 0
fbx_exporter_switch_stats_rx_fragments_packets{port="3"} 0
# HELP fbx_exporter_switch_stats_rx_good_bytes rx good bytes
# TYPE fbx_exporter_switch_stats_rx_good_bytes gauge
fbx_exporter_switch_stats_rx_good_bytes{port="1"} 0
fbx_exporter_switch_stats_rx_good_bytes{port="2"} 9211652372
fbx_exporter_switch_stats_rx_good_bytes{port="3"} 218957294335
# HELP fbx_exporter_switch_stats_rx_good_packets tx good packets
# TYPE fbx_exporter_switch_stats_rx_good_packets gauge
fbx_exporter_switch_stats_rx_good_packets{port="1"} 0
fbx_exporter_switch_stats_rx_good_packets{port="2"} 99542885
fbx_exporter_switch_stats_rx_good_packets{port="3"} 633240044
# HELP fbx_exporter_switch_stats_rx_jabber_packets rx jabber packets
# TYPE fbx_exporter_switch_stats_rx_jabber_packets gauge
fbx_exporter_switch_stats_rx_jabber_packets{port="1"} 0
fbx_exporter_switch_stats_rx_jabber_packets{port="2"} 0
fbx_exporter_switch_stats_rx_jabber_packets{port="3"} 0
# HELP fbx_exporter_switch_stats_rx_multicast_packets rx multicast packets
# TYPE fbx_exporter_switch_stats_rx_multicast_packets gauge
fbx_exporter_switch_stats_rx_multicast_packets{port="1"} 0
fbx_exporter_switch_stats_rx_multicast_packets{port="2"} 135248
fbx_exporter_switch_stats_rx_multicast_packets{port="3"} 224487
# HELP fbx_exporter_switch_stats_rx_oversize_packets rx oversize packets
# TYPE fbx_exporter_switch_stats_rx_oversize_packets gauge
fbx_exporter_switch_stats_rx_oversize_packets{port="1"} 0
fbx_exporter_switch_stats_rx_oversize_packets{port="2"} 0
fbx_exporter_switch_stats_rx_oversize_packets{port="3"} 0
# HELP fbx_exporter_switch_stats_rx_packets_rate rx packet rate
# TYPE fbx_exporter_switch_stats_rx_packets_rate gauge
fbx_exporter_switch_stats_rx_packets_rate{port="1"} 0
fbx_exporter_switch_stats_rx_packets_rate{port="2"} 0
fbx_exporter_switch_stats_rx_packets_rate{port="3"} 19
# HELP fbx_exporter_switch_stats_rx_pause rx pause
# TYPE fbx_exporter_switch_stats_rx_pause gauge
fbx_exporter_switch_stats_rx_pause{port="1"} 0
fbx_exporter_switch_stats_rx_pause{port="2"} 0
fbx_exporter_switch_stats_rx_pause{port="3"} 0
# HELP fbx_exporter_switch_stats_rx_undersize_packets rx undersize packets
# TYPE fbx_exporter_switch_stats_rx_undersize_packets gauge
fbx_exporter_switch_stats_rx_undersize_packets{port="1"} 0
fbx_exporter_switch_stats_rx_undersize_packets{port="2"} 0
fbx_exporter_switch_stats_rx_undersize_packets{port="3"} 0
# HELP fbx_exporter_switch_stats_rx_unicast_packets rx unicast packets
# TYPE fbx_exporter_switch_stats_rx_unicast_packets gauge
fbx_exporter_switch_stats_rx_unicast_packets{port="1"} 0
fbx_exporter_switch_stats_rx_unicast_packets{port="2"} 99399081
fbx_exporter_switch_stats_rx_unicast_packets{port="3"} 632995221
# HELP fbx_exporter_switch_stats_tx_broadcast_packets tx broadcast packets
# TYPE fbx_exporter_switch_stats_tx_broadcast_packets gauge
fbx_exporter_switch_stats_tx_broadcast_packets{port="1"} 0
fbx_exporter_switch_stats_tx_broadcast_packets{port="2"} 569910
fbx_exporter_switch_stats_tx_broadcast_packets{port="3"} 4034280
# HELP fbx_exporter_switch_stats_tx_bytes tx bytes
# TYPE fbx_exporter_switch_stats_tx_bytes gauge
fbx_exporter_switch_stats_tx_bytes{port="1"} 0
fbx_exporter_switch_stats_tx_bytes{port="2"} 597123401464
fbx_exporter_switch_stats_tx_bytes{port="3"} 1167045290178
# HELP fbx_exporter_switch_stats_tx_bytes_rate tx bytes rate
# TYPE fbx_exporter_switch_stats_tx_bytes_rate gauge
fbx_exporter_switch_stats_tx_bytes_rate{port="1"} 0
fbx_exporter_switch_stats_tx_bytes_rate{port="2"} 0
fbx_exporter_switch_stats_tx_bytes_rate{port="3"} 5768
# HELP fbx_exporter_switch_stats_tx_collisions tx collisions
# TYPE fbx_exporter_switch_stats_tx_collisions gauge
fbx_exporter_switch_stats_tx_collisions{port="1"} 0
fbx_exporter_switch_stats_tx_collisions{port="2"} 0
fbx_exporter_switch_stats_tx_collisions{port="3"} 0
# HELP fbx_exporter_switch_stats_tx_deferred tx deferred
# TYPE fbx_exporter_switch_stats_tx_deferred gauge
fbx_exporter_switch_stats_tx_deferred{port="1"} 0
fbx_exporter_switch_stats_tx_deferred{port="2"} 0
fbx_exporter_switch_stats_tx_deferred{port="3"} 0
# HELP fbx_exporter_switch_stats_tx_excessive tx excessive
# TYPE fbx_exporter_switch_stats_tx_excessive gauge
fbx_exporter_switch_stats_tx_excessive{port="1"} 0
fbx_exporter_switch_stats_tx_excessive{port="2"} 0
fbx_exporter_switch_stats_tx_excessive{port="3"} 0
# HELP fbx_exporter_switch_stats_tx_fcs tx fcs
# TYPE fbx_exporter_switch_stats_tx_fcs gauge
fbx_exporter_switch_stats_tx_fcs{port="1"} 0
fbx_exporter_switch_stats_tx_fcs{port="2"} 0
fbx_exporter_switch_stats_tx_fcs{port="3"} 0
# HELP fbx_exporter_switch_stats_tx_late tx late
# TYPE fbx_exporter_switch_stats_tx_late gauge
fbx_exporter_switch_stats_tx_late{port="1"} 0
fbx_exporter_switch_stats_tx_late{port="2"} 0
fbx_exporter_switch_stats_tx_late{port="3"} 0
# HELP fbx_exporter_switch_stats_tx_multicast_packets tx multicast packets
# TYPE fbx_exporter_switch_stats_tx_multicast_packets gauge
fbx_exporter_switch_stats_tx_multicast_packets{port="1"} 0
fbx_exporter_switch_stats_tx_multicast_packets{port="2"} 47682
fbx_exporter_switch_stats_tx_multicast_packets{port="3"} 538352
# HELP fbx_exporter_switch_stats_tx_multiple tx multiple
# TYPE fbx_exporter_switch_stats_tx_multiple gauge
fbx_exporter_switch_stats_tx_multiple{port="1"} 0
fbx_exporter_switch_stats_tx_multiple{port="2"} 0
fbx_exporter_switch_stats_tx_multiple{port="3"} 0
# HELP fbx_exporter_switch_stats_tx_packets tx packets
# TYPE fbx_exporter_switch_stats_tx_packets gauge
fbx_exporter_switch_stats_tx_packets{port="1"} 0
fbx_exporter_switch_stats_tx_packets{port="2"} 422143529
fbx_exporter_switch_stats_tx_packets{port="3"} 1257269841
# HELP fbx_exporter_switch_stats_tx_packets_rate tx packets rate
# TYPE fbx_exporter_switch_stats_tx_packets_rate gauge
fbx_exporter_switch_stats_tx_packets_rate{port="1"} 0
fbx_exporter_switch_stats_tx_packets_rate{port="2"} 0
fbx_exporter_switch_stats_tx_packets_rate{port="3"} 15
# HELP fbx_exporter_switch_stats_tx_pause tx pause
# TYPE fbx_exporter_switch_stats_tx_pause gauge
fbx_exporter_switch_stats_tx_pause{port="1"} 0
fbx_exporter_switch_stats_tx_pause{port="2"} 0
fbx_exporter_switch_stats_tx_pause{port="3"} 0
# HELP fbx_exporter_switch_stats_tx_single tx single
# TYPE fbx_exporter_switch_stats_tx_single gauge
fbx_exporter_switch_stats_tx_single{port="1"} 0
fbx_exporter_switch_stats_tx_single{port="2"} 0
fbx_exporter_switch_stats_tx_single{port="3"} 0
# HELP fbx_exporter_switch_stats_tx_unicast_packets tx unicast packets
# TYPE fbx_exporter_switch_stats_tx_unicast_packets gauge
fbx_exporter_switch_stats_tx_unicast_packets{port="1"} 0
fbx_exporter_switch_stats_tx_unicast_packets{port="2"} 421525937
fbx_exporter_switch_stats_tx_unicast_packets{port="3"} 1252697209
```