### PR TITLE
fix shared resources deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "freebox-exporter-rs"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freebox-exporter-rs"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/core/authenticator/session_token_provider.rs
+++ b/src/core/authenticator/session_token_provider.rs
@@ -23,7 +23,7 @@ use super::{application_token_provider::ApplicationTokenProvider, common::Sessio
 pub struct SessionTokenProvider<'a> {
     issued_on: Arc<Mutex<DateTime<Utc>>>,
     value: Arc<Mutex<String>>,
-    app_token_storage: Arc<Mutex<&'a Box<dyn ApplicationTokenProvider>>>,
+    app_token_storage: &'a Box<dyn ApplicationTokenProvider>,
     api_url: String,
 }
 
@@ -34,7 +34,7 @@ impl<'a> SessionTokenProvider<'a> {
                 Utc.with_ymd_and_hms(01, 01, 01, 00, 00, 01).unwrap(),
             )),
             value: Arc::new(Mutex::new(String::new())),
-            app_token_storage: Arc::new(Mutex::new(app_token_storage)),
+            app_token_storage,
             api_url,
         }
     }
@@ -65,9 +65,7 @@ impl<'a> SessionTokenProvider<'a> {
     pub async fn login(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         debug!("login in");
 
-        let storage_guard = self.app_token_storage.lock().await;
-
-        let token = storage_guard.get().await;
+        let token = self.app_token_storage.get().await;
 
         let token = token.as_ref().to_owned();
 

--- a/src/core/logger.rs
+++ b/src/core/logger.rs
@@ -11,7 +11,9 @@ impl LogLineFilter for CustomLogFilter {
     ) -> std::io::Result<()> {
         let path = record.module_path().unwrap_or_default();
 
-        if path.starts_with("reqwest") || path.starts_with("prometheus_exporter") {
+        if record.level() != log::Level::Debug
+            && (path.starts_with("reqwest") || path.starts_with("prometheus_exporter"))
+        {
             return Ok(());
         }
 


### PR DESCRIPTION
This pull request includes several changes to improve the codebase by simplifying the structure and enhancing the logging mechanism. The most important changes include removing unnecessary `Arc` and `Mutex` wrappers, updating the version in `Cargo.toml`, and modifying the logging filter.

Codebase simplification:

* [`src/core/authenticator/session_token_provider.rs`](diffhunk://#diff-d7a9cba57463ad6b5478c1fdb0bad2a7eb998cdc6442dd14fc0a15b7c9a97624L26-R26): Removed unnecessary `Arc` and `Mutex` wrappers from `app_token_storage` in `SessionTokenProvider`. [[1]](diffhunk://#diff-d7a9cba57463ad6b5478c1fdb0bad2a7eb998cdc6442dd14fc0a15b7c9a97624L26-R26) [[2]](diffhunk://#diff-d7a9cba57463ad6b5478c1fdb0bad2a7eb998cdc6442dd14fc0a15b7c9a97624L37-R37) [[3]](diffhunk://#diff-d7a9cba57463ad6b5478c1fdb0bad2a7eb998cdc6442dd14fc0a15b7c9a97624L68-R68)
* [`src/core/common/http_client_factory.rs`](diffhunk://#diff-fb2d79e5d5ec5ea05f72d6d98a51f2749dd8a34f2d78b1ad1fea6fdff9de924eL5-L6): Removed unnecessary `Arc` and `Mutex` wrappers from `token_provider` in `AuthenticatedHttpClientFactory`. [[1]](diffhunk://#diff-fb2d79e5d5ec5ea05f72d6d98a51f2749dd8a34f2d78b1ad1fea6fdff9de924eL5-L6) [[2]](diffhunk://#diff-fb2d79e5d5ec5ea05f72d6d98a51f2749dd8a34f2d78b1ad1fea6fdff9de924eL15-R21) [[3]](diffhunk://#diff-fb2d79e5d5ec5ea05f72d6d98a51f2749dd8a34f2d78b1ad1fea6fdff9de924eL33-R31)

Version update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Updated the version from `0.0.12` to `0.0.13`.

Logging enhancement:

* [`src/core/logger.rs`](diffhunk://#diff-b5524de406e607b39773229071cf680070ffb2f3e8f20606c890a44c7a8a6ac3L14-R16): Modified the logging filter to exclude non-debug level logs for modules `reqwest` and `prometheus_exporter`.