### PR TITLE
add k8s files + fix containerfile build

### DIFF
--- a/ContainerFile
+++ b/ContainerFile
@@ -12,6 +12,7 @@ COPY Cargo.toml Cargo.lock ./
 
 # Copy the source code
 COPY src ./src
+COPY includes ./includes
 
 # Build the project
 RUN cargo build --release

--- a/kubernetes/freebox-exporter-rs-configmap.yml
+++ b/kubernetes/freebox-exporter-rs-configmap.yml
@@ -42,6 +42,8 @@ data:
     wifi = true
     # Exposes dhcp
     dhcp = true
+    # Exposes system
+    system = true
     # Sets metrics prefix, it cannot be empty
     # Warning if you are using the exporter Grafana board, changing this value will cause the board to be unable to retrieve data if you do not update it
     prefix = "fbx_exporter"

--- a/kubernetes/freebox-exporter-rs-configmap.yml
+++ b/kubernetes/freebox-exporter-rs-configmap.yml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: freebox-exporter-rs-config
+  namespace: monitoring
+  labels:
+    app: freebox-exporter-rs
+data:
+  config.toml: |
+    [api]
+    # Acceptable values: "router" or "bridge"
+    # These values will determine whether use discovery or not, see: https://github.com/shackerd/freebox-exporter-rs/issues/2#issuecomment-2234856496
+    # * discovery on:
+    #   * Traffic will be using host like xxxxxxxx.fbxos.fr
+    #   * FQDN resolves to your public IP address.
+    #   * However, you do not need to activate remote_access from local network to get API working.
+    # * discovery off:
+    #   * Traffic will be using host mafreebox.freebox.fr
+    #   * FQDN resolves to a public IP address (not yours), which allows you to reach your freebox API even if it's set to bridge mode.
+    # Remark:
+    #   * If the application is set in "bridge" mode, it works even when Freebox is set to "router" mode but some functionalities will be disabled
+    #   * If the application is set in "router" mode, it does not work when Freebox is set to "bridge" mode
+    mode = "bridge"
+
+    # Refresh wait interval in seconds, application will send requests to the freebox host on each refresh iteration
+    # This does not affect prometheus scrap agents, application will use cached values between calls
+    # Remark:
+    #   more you set API exposition (c.f: [metrics] section) more requests will be sent,
+    #   setting a too low interval between refreshs could lead to request rate limiting from freebox host
+    refresh = 5
+
+    [metrics]
+    # Exposes connection
+    connection = true
+    # Exposes lan, this option may not work in bridge_mode
+    lan = true
+    # Exposes lan browser, this option does not work in bridge_mode
+    lan_browser = true
+    # Exposes switch, this option may not work properly in bridge_mode
+    switch = true
+    # Exposes wifi
+    wifi = true
+    # Exposes dhcp
+    dhcp = true
+    # Sets metrics prefix, it cannot be empty
+    # Warning if you are using the exporter Grafana board, changing this value will cause the board to be unable to retrieve data if you do not update it
+    prefix = "fbx_exporter"
+
+    [core]
+    # Specify where to store data for exporter such as APP_TOKEN, logs, etc.
+    data_directory = "/var/log/freebox-exporter-rs"
+    # Specify which TCP port to listen to, for the /metrics HTTP endpoint
+    port = 9100
+
+    [log]
+    # Specify which log level to use
+    # Acceptable values :
+    #   * "Off"     : A level lower than all log levels
+    #   * "Error"   : Corresponds to the `Error` log level
+    #   * "Warn"    : Corresponds to the `Warn` log level
+    #   * "Info"    : Corresponds to the `Info` log level
+    #   * "Debug"   : Corresponds to the `Debug` log level
+    #   * "Trace"   : Corresponds to the `Trace` log level
+    level = "Info"
+    # Specify how long application should keep compressed log files, value is in days
+    retention = 31

--- a/kubernetes/freebox-exporter-rs-service.yml
+++ b/kubernetes/freebox-exporter-rs-service.yml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: freebox-exporter-rs
+  namespace: monitoring
+spec:
+  selector:
+    app: freebox-exporter-rs
+  type: ClusterIP
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9100
+    targetPort: 9100

--- a/kubernetes/freebox-exporter-rs-statefulset.yml
+++ b/kubernetes/freebox-exporter-rs-statefulset.yml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: freebox-exporter-rs
+  namespace: monitoring
+spec:
+  serviceName: "freebox-exporter-rs"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: freebox-exporter-rs
+  template:
+    metadata:
+      labels:
+        app: freebox-exporter-rs
+    spec:      
+      volumes:
+      - name: freebox-exporter-rs-config
+        configMap:
+          name: freebox-exporter-rs-config
+          items:
+            - key: config.toml
+              path: config.toml
+      containers:
+      - name: freebox-exporter-rs
+        image: shackerd/freebox-exporter-rs:latest
+        ports:
+        - containerPort: 9100
+          name: http      
+          protocol: TCP        
+        volumeMounts:
+        - name: freebox-exporter-rs-data
+          mountPath: /var/log/freebox-exporter-rs                  
+        - name: freebox-exporter-rs-config
+          mountPath: /conf
+        resources:
+          requests:
+            cpu: "20m"
+            memory: "55M"
+          limits:
+            cpu: "200m"
+            memory: "256M"
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 9100
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 9100
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /metrics
+            port: 9100
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+        command:
+          - "/root/freebox-exporter-rs"
+        args: ["-c", "/conf/config.toml" ,"auto"]
+  volumeClaimTemplates:
+  - metadata:
+      name: freebox-exporter-rs-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+      storageClassName: "longhorn" # you might want to change this to your own storage class


### PR DESCRIPTION
This pull request introduces configurations and Kubernetes manifests for deploying the `freebox-exporter-rs` application. Key changes include adding a `ConfigMap` for application configuration, defining a `Service` and `StatefulSet` for deployment, and updating the container build process to include additional source files.

### Kubernetes Deployment Configuration:

* **ConfigMap for Application Settings**: Added a `ConfigMap` in `kubernetes/freebox-exporter-rs-configmap.yml` to define application settings, including API mode, refresh intervals, metrics exposure, logging configuration, and data storage paths.
* **StatefulSet for Deployment**: Created a `StatefulSet` in `kubernetes/freebox-exporter-rs-statefulset.yml` to manage the deployment of `freebox-exporter-rs`. It includes volume mounts for configuration and data, resource requests/limits, and probes for liveness, readiness, and startup.
* **Service for Network Access**: Added a `Service` in `kubernetes/freebox-exporter-rs-service.yml` to expose the application on port 9100 within the cluster using a `ClusterIP` type.

### Build Process Update:

* **Additional Source Files**: Updated the `ContainerFile` to copy the `includes` directory into the container during the build process.