### PR TITLE
fix container image generation

### DIFF
--- a/ContainerFile
+++ b/ContainerFile
@@ -67,21 +67,24 @@ RUN cargo +nightly build --release --target arm-unknown-linux-musleabihf
 
 FROM alpine:latest AS final-amd64
 RUN apk add --no-cache ca-certificates
-COPY --from=builder-amd64 /usr/src/freebox-exporter-rs/target/x86_64-unknown-linux-musl/release/freebox-exporter-rs /freebox-exporter-rs
+COPY --from=builder-amd64 /usr/src/freebox-exporter-rs/target/x86_64-unknown-linux-musl/release/freebox-exporter-rs /usr/bin/freebox-exporter-rs
 COPY config.toml /etc/freebox-exporter-rs/config.toml
+RUN ln -s /usr/bin/freebox-exporter-rs /root/freebox-exporter-rs
 EXPOSE 9102
-CMD ["/freebox-exporter-rs"]
+CMD ["/usr/bin/freebox-exporter-rs"]
 
 FROM alpine:latest AS final-arm64
 RUN apk add --no-cache ca-certificates
-COPY --from=builder-arm64 /usr/src/freebox-exporter-rs/target/aarch64-unknown-linux-musl/release/freebox-exporter-rs /freebox-exporter-rs
+COPY --from=builder-arm64 /usr/src/freebox-exporter-rs/target/aarch64-unknown-linux-musl/release/freebox-exporter-rs /usr/bin/freebox-exporter-rs
 COPY config.toml /etc/freebox-exporter-rs/config.toml
+RUN ln -s /usr/bin/freebox-exporter-rs /root/freebox-exporter-rs
 EXPOSE 9102
-CMD ["/freebox-exporter-rs"]
+CMD ["/usr/bin/freebox-exporter-rs"]
 
 FROM alpine:latest AS final-armv7
 RUN apk add --no-cache ca-certificates
-COPY --from=builder-armv7 /usr/src/freebox-exporter-rs/target/arm-unknown-linux-musleabihf/release/freebox-exporter-rs /freebox-exporter-rs
+COPY --from=builder-armv7 /usr/src/freebox-exporter-rs/target/arm-unknown-linux-musleabihf/release/freebox-exporter-rs /usr/bin/freebox-exporter-rs
 COPY config.toml /etc/freebox-exporter-rs/config.toml
+RUN ln -s /usr/bin/freebox-exporter-rs /root/freebox-exporter-rs
 EXPOSE 9102
-CMD ["/freebox-exporter-rs"]
+CMD ["/usr/bin/freebox-exporter-rs"]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Options:
 Running with docker
 
 ``` bash
-docker pull docker.io/shackerd/freebox-exporter-rs:latest
+docker pull ghcr.io/shackerd/freebox-exporter-rs:latest
 ```
 
 ``` yaml
@@ -91,7 +91,7 @@ version: '3.8'
 
 services:
   freebox-exporter:
-    image: docker.io/shackerd/freebox-exporter-rs:latest
+    image: ghcr.io/shackerd/freebox-exporter-rs:latest
     container_name: freebox-exporter
     volumes:
       - ./config:/etc/freebox-exporter-rs
@@ -99,7 +99,7 @@ services:
     ports:
       - "9102:9102"
     restart: unless-stopped
-    command: ["/root/freebox-exporter-rs", "-c", "/etc/freebox-exporter-rs/config.toml" ,"auto"]
+    command: ["/usr/bin/freebox-exporter-rs", "-c", "/etc/freebox-exporter-rs/config.toml" ,"auto"]
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
This pull request updates the container build and usage instructions to standardize the binary location, improve compatibility, and switch to a new container registry. The changes affect both the `ContainerFile` and the `README.md` documentation, ensuring consistency in how the binary is referenced and how users should run the container.

**Container build and runtime changes:**

* The built binary is now copied to `/usr/bin/freebox-exporter-rs` instead of the root directory, and a symbolic link is created at `/root/freebox-exporter-rs` for backward compatibility. The container's `CMD` is updated to use the new binary location for all target architectures.

**Documentation updates:**

* The Docker image reference in the `README.md` is updated from `docker.io/shackerd/freebox-exporter-rs:latest` to `ghcr.io/shackerd/freebox-exporter-rs:latest`, reflecting a move to GitHub Container Registry.
* The sample Docker Compose command in the `README.md` is updated to use `/usr/bin/freebox-exporter-rs` as the binary path, matching the new container layout.