### PR TITLE
Update command path in README for freebox-exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ services:
     ports:
       - "9102:9102"
     restart: unless-stopped
-    command: ["/root/freebox-exporter-rs", "-c", "/etc/freebox-exporter-rs/config.toml" ,"auto"]
+    command: ["/freebox-exporter-rs", "-c", "/etc/freebox-exporter-rs/config.toml" ,"auto"]
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
I saw command changed since last update, i correct it.