### PR TITLE
Fix wifi host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "freebox-exporter-rs"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "freebox-exporter-rs"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freebox-exporter-rs"
-version = "0.0.21"
+version = "0.0.22"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freebox-exporter-rs"
-version = "0.0.22"
+version = "0.0.23"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/mappers/wifi.rs
+++ b/src/mappers/wifi.rs
@@ -473,7 +473,7 @@ impl<'a> WifiMetricMap<'a> {
             let flags = station.flags.as_ref().unwrap();
 
             let host = match station.host.as_ref() {
-                Some(h) => h,
+                Some(h) => h.clone(),
                 None => {
                     info!("no host information found for station {}", station.mac.as_ref().unwrap());
 
@@ -499,7 +499,7 @@ impl<'a> WifiMetricMap<'a> {
                         names: Some(vec![]),
                         primary_name_manual: Some(false),
                     };
-                    empty_host.as_any_ref()
+                    empty_host
                 }
             };
 

--- a/src/mappers/wifi.rs
+++ b/src/mappers/wifi.rs
@@ -480,7 +480,7 @@ impl<'a> WifiMetricMap<'a> {
                     let l3connectivities = 
                         L3Connectivities { 
                             addr: Some("unknown".to_string()), 
-                            af: Some("unknown".to_string()), 
+                            af: Some("ipv4".to_string()), 
                             last_time_reachable: Some(0), 
                             last_activity: Some(0), 
                             active: Some(true), 
@@ -514,8 +514,14 @@ impl<'a> WifiMetricMap<'a> {
                 .iter()
                 .filter(|l| l.af.as_ref().unwrap_or(&"unknown".to_string()) == "ipv4")
                 .next();
+            
+            if l3.is_none() {
+                return Err(Box::new(FreeboxResponseError::new(
+                    format!("no ipv4 connectivity found for station {}", station.mac.as_ref().unwrap()),
+                )));
+            }
 
-            let l3 = l3.unwrap(); // take the most recent entry
+            let l3 = l3.unwrap(); // take the most recent entry 
             let mac = station.mac.to_owned().unwrap_or("unknown".to_string());
             let rx_bitrate = last_rx.bitrate.unwrap_or(0);
             let rx_mcs = last_rx.mcs.unwrap_or(0);


### PR DESCRIPTION
This pull request improves the robustness of the WiFi metrics mapping logic by handling cases where host information is missing for a station. Instead of panicking when host data is absent, the code now logs a message and creates a placeholder host with default values. Additionally, error handling for missing IPv4 connectivity has been clarified.

**Robustness improvements for missing data:**

* When a `Station` lacks host information, the code now logs a message and constructs a default `Host` object with placeholder values, instead of panicking or failing unexpectedly. (`src/mappers/wifi.rs`)
* The error message for missing IPv4 connectivity has been updated for clarity, changing "no ipv4 address found" to "no ipv4 connectivity found". (`src/mappers/wifi.rs`)

**Dependency updates:**

* The imports for `L2Ident` and `L3Connectivities` have been added to support the new default host construction logic. (`src/mappers/wifi.rs`)