### PR TITLE
Support NAS API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "6.0.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "freebox-exporter-rs"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "ascii"
@@ -135,9 +135,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -162,9 +162,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -178,9 +178,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -197,9 +197,9 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -246,6 +246,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -340,9 +350,9 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -528,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -543,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -553,15 +563,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -570,15 +580,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -587,21 +597,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -611,7 +621,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -638,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
@@ -990,7 +999,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -1006,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -1034,9 +1043,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1076,15 +1085,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1169,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -1190,7 +1199,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -1220,7 +1229,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1275,7 +1284,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1297,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
@@ -1354,9 +1363,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1458,18 +1467,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"
@@ -1477,7 +1486,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1505,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1565,11 +1574,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1578,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1647,12 +1656,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1660,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1813,9 +1822,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1848,8 +1857,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -1865,12 +1874,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1965,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -1982,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2050,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.7+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -2084,7 +2093,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -2141,9 +2150,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -2238,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2251,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2265,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2275,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2288,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -2323,7 +2332,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2331,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2598,9 +2607,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "wiremock"
@@ -2683,7 +2692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -2804,6 +2813,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freebox-exporter-rs"
-version = "0.0.24"
+version = "0.0.25"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You will find on Grafana [gallery](https://grafana.com/grafana/dashboards/21957)
   * &#9989; Switch: **100%**
   * &#9989; Wi-Fi: **100%**%
   * &#9989; System: **100%**
+  * &#9989; Storage/NAS: **100%**
   * &#10060; VPN Server: 0%
   * &#10060; VPN Client: 0%
 
@@ -108,6 +109,47 @@ Example configuration:
 unresolved_station_hostnames = "ignore"  # or "relabel"
 ```
 
+## NAS Storage Metrics
+
+The exporter provides comprehensive metrics for Freebox NAS storage functionality, exposing detailed information about attached disks and their partitions.
+
+### Disk Metrics
+
+- **Storage capacity**: Total disk size in bytes
+- **Disk state**: Current state (enabled, disabled, error, formatting)
+- **Temperature**: Disk temperature in Celsius (for supported drives)
+- **Power management**: Spinning status, idle state, and timing information
+- **Hardware info**: Disk type (internal, USB, SATA), model, serial, firmware
+- **Performance**: Active/idle duration, time before spindown
+- **Physical info**: Connector ID, partition table type
+- **Operations**: Progress percentage and step counts for ongoing operations
+
+### Partition Metrics
+
+- **Storage usage**: Total, used, and free space in bytes
+- **Partition state**: Mount status (mounted, unmounted, error, etc.)
+- **Filesystem info**: Filesystem type and partition labels
+- **Health**: FSCK results and status
+- **Operations**: Progress percentage and step counts for partition operations
+
+### Configuration
+
+Enable NAS metrics by setting `nas = true` in your configuration file:
+
+```toml
+[metrics]
+nas = true
+```
+
+**Note**: NAS metrics use the Freebox Storage API which is marked as **[UNSTABLE]** in the official documentation and may change in future Freebox firmware updates.
+
+Example metrics exposed:
+```
+fbx_exporter_nas_disk_total_bytes{disk_id="1",disk_type="internal",model="Hitachi HCC545025B9A300",serial="GSCH35VC"} 250059350016
+fbx_exporter_nas_disk_temperature_celsius{disk_id="1",disk_type="internal",model="Hitachi HCC545025B9A300",serial="GSCH35VC"} 51
+fbx_exporter_nas_partition_used_bytes{partition_id="3",disk_id="1",label="Disque dur",fstype="ext4"} 164520534016
+```
+
 ## Running project
 
 Running with docker
@@ -162,6 +204,8 @@ wifi = true
 dhcp = true
 # Exposes system
 system = true
+# Exposes NAS storage information (disks and partitions)
+nas = true
 # Sets metrics prefix, it cannot be empty
 # Warning if you are using the exporter Grafana board, changing this value will cause the board to be unable to retrieve data if you do not update it
 prefix = "fbx_exporter"

--- a/config.toml
+++ b/config.toml
@@ -21,6 +21,8 @@ wifi = true
 dhcp = true
 # Exposes system
 system = true
+# Exposes NAS storage information (disks and partitions)
+nas = true
 # Sets metrics prefix, it cannot be empty
 # Warning if you are using the exporter Grafana board, changing this value will cause the board to be unable to retrieve data if you do not update it
 prefix = "fbx_exporter"

--- a/grafana-board.json
+++ b/grafana-board.json
@@ -597,6 +597,23 @@
           "range": true,
           "refId": "C",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_system_temp_cpu{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "CPU {{core}}",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
         }
       ],
       "title": "CPU(s) temperatures",
@@ -2428,6 +2445,23 @@
           "legendFormat": "SW",
           "range": true,
           "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_system_temp_cpu{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "CPU {{core}}",
+          "range": true,
+          "refId": "D",
           "useBackend": false
         }
       ],
@@ -5874,6 +5908,788 @@
       ],
       "title": "Dispatch per iface",
       "type": "piechart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 116
+      },
+      "id": 55,
+      "panels": [],
+      "title": "NAS",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 120000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 117
+      },
+      "id": 56,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_nas_disk_temperature_celsius{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{model}} ({{disk_id}})",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Disk Temperature",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "1=enabled, 0=disabled, -1=error, 2=formatting",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 120000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 117
+      },
+      "id": 57,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_nas_disk_state{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{model}} ({{state}})",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Disk State",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "1=spinning, 0=not spinning",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 120000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 125
+      },
+      "id": 58,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_nas_disk_spinning{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{model}} ({{disk_id}})",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Disk Spinning",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 120000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 125
+      },
+      "id": 59,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_nas_disk_idle_duration_seconds{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{model}} ({{disk_id}})",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Disk Idle Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 120000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 133
+      },
+      "id": 60,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_nas_partition_total_bytes{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Total {{label}} ({{fstype}})",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_nas_partition_used_bytes{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Used {{label}} ({{fstype}})",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_nas_partition_free_bytes{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Free {{label}} ({{fstype}})",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        }
+      ],
+      "title": "Partition Space",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "1=mounted, 0=unmounted, -1=error, 2=checking, 3=formatting, 4=mounting, 5=maintenance, 6=unmounting, 7=ejecting",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 120000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 141
+      },
+      "id": 61,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_nas_partition_state{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{label}} ({{state}})",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Partition State",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 120000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 141
+      },
+      "id": 62,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_nas_disk_active_duration_seconds{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{model}} ({{disk_id}})",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Disk Active Duration",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",
@@ -5988,6 +6804,6 @@
   "timezone": "browser",
   "title": "freebox-exporter-rs",
   "uid": "deddg8kngnmyoa",
-  "version": 27,
+  "version": 28,
   "weekStart": ""
 }

--- a/src/core/capabilities/mod.rs
+++ b/src/core/capabilities/mod.rs
@@ -66,6 +66,7 @@ impl<'a> CapabilitiesAgent<'a> {
             switch: Some(is_router),
             wifi: Some(is_wifi_enabled),
             dhcp: Some(is_router),
+            nas: Some(true), // NAS is always available
             network_mode: lan_config.mode,
         })
     }
@@ -107,5 +108,6 @@ pub struct Capabilities {
     pub switch: Option<bool>,
     pub wifi: Option<bool>,
     pub dhcp: Option<bool>,
+    pub nas: Option<bool>,
     pub network_mode: Option<String>,
 }

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -1,4 +1,4 @@
-use clap::{arg, command, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]

--- a/src/core/configuration/sections.rs
+++ b/src/core/configuration/sections.rs
@@ -16,7 +16,6 @@ pub struct PoliciesConfiguration {
     pub unresolved_station_hostnames: Option<String>,
 }
 
-
 #[derive(Deserialize, Clone, Debug)]
 pub struct CapabilitiesConfiguration {
     pub connection: Option<bool>,
@@ -26,6 +25,7 @@ pub struct CapabilitiesConfiguration {
     pub switch: Option<bool>,
     pub wifi: Option<bool>,
     pub dhcp: Option<bool>,
+    pub nas: Option<bool>,
     pub prefix: Option<String>,
 }
 

--- a/src/core/configuration/tests.rs
+++ b/src/core/configuration/tests.rs
@@ -109,6 +109,7 @@ unresolved_station_hostnames = \"ignore\"";
                 switch: None,
                 wifi: None,
                 dhcp: None,
+                nas: None,
             },
             policies: Some(PoliciesConfiguration {
                 unresolved_station_hostnames: None,
@@ -136,6 +137,7 @@ unresolved_station_hostnames = \"ignore\"";
                 switch: None,
                 wifi: None,
                 dhcp: None,
+                nas: None,
             },
             policies: Some(PoliciesConfiguration {
                 unresolved_station_hostnames: None,
@@ -163,6 +165,7 @@ unresolved_station_hostnames = \"ignore\"";
                 switch: None,
                 wifi: None,
                 dhcp: None,
+                nas: None,
             },
             policies: Some(PoliciesConfiguration {
                 unresolved_station_hostnames: None,
@@ -197,6 +200,7 @@ unresolved_station_hostnames = \"ignore\"";
                 switch: None,
                 wifi: None,
                 dhcp: None,
+                nas: None,
             },
             policies: Some(PoliciesConfiguration {
                 unresolved_station_hostnames: None,
@@ -218,12 +222,13 @@ unresolved_station_hostnames = \"ignore\"";
             metrics: CapabilitiesConfiguration {
                 connection: None,
                 system: None,
-                prefix: Some(" ".to_string()),
+                prefix: None,
                 lan_browser: None,
                 lan: None,
                 switch: None,
                 wifi: None,
                 dhcp: None,
+                nas: None,
             },
             policies: Some(PoliciesConfiguration {
                 unresolved_station_hostnames: None,
@@ -245,12 +250,13 @@ unresolved_station_hostnames = \"ignore\"";
             metrics: CapabilitiesConfiguration {
                 connection: None,
                 system: None,
-                prefix: Some("fbx_exporter".to_string()),
+                prefix: Some("valid_prefix".to_string()),
                 lan_browser: None,
                 lan: None,
                 switch: None,
                 wifi: None,
                 dhcp: None,
+                nas: None,
             },
             policies: Some(PoliciesConfiguration {
                 unresolved_station_hostnames: None,

--- a/src/mappers/mod.rs
+++ b/src/mappers/mod.rs
@@ -4,6 +4,7 @@ use connection::ConnectionMetricMap;
 use lan::LanMetricMap;
 use lanbrowser::LanBrowserMetricMap;
 use log::{error, warn};
+use nas::NasMetricMap;
 use switch::SwitchMetricMap;
 use system::SystemMetricMap;
 
@@ -19,6 +20,7 @@ pub mod connection;
 pub mod dhcp;
 pub mod lan;
 pub mod lanbrowser;
+pub mod nas;
 pub mod switch;
 pub mod system;
 pub mod wifi;
@@ -149,6 +151,21 @@ impl<'a> Mapper<'a> {
             }
         } else {
             warn!("DHCP metrics are disabled by default, missing entry in the configuration file");
+        }
+
+        if let Some(e) = conf.nas {
+            if e {
+                if !caps.nas.unwrap_or(false) {
+                    warn!("NAS is incompatible with detected freebox mode ({}), the option has been disabled", network_mode);
+                } else {
+                    maps.push(Box::new(NasMetricMap::new(
+                        factory,
+                        conf.prefix.to_owned().unwrap(),
+                    )));
+                }
+            }
+        } else {
+            warn!("NAS metrics are disabled by default, missing entry in the configuration file");
         }
 
         Self { maps }

--- a/src/mappers/nas.rs
+++ b/src/mappers/nas.rs
@@ -1,0 +1,716 @@
+use async_trait::async_trait;
+use log::debug;
+use prometheus_exporter::prometheus::{
+    register_int_gauge_vec, IntGaugeVec,
+};
+use reqwest::Client;
+use serde::Deserialize;
+
+use super::MetricMap;
+use crate::core::common::{
+    http_client_factory::{AuthenticatedHttpClientFactory, ManagedHttpClient},
+    transport::{FreeboxResponse, FreeboxResponseError},
+};
+
+/// NAS Storage Metrics for Freebox API
+/// 
+/// This module provides metrics collection for Freebox storage devices (NAS functionality).
+/// It implements the Storage API as documented at: https://dev.freebox.fr/sdk/os/storage/
+/// 
+/// The implementation uses the `/api/v4/storage/disk/` endpoint to retrieve information about:
+/// - Storage disks (internal, USB, SATA)
+/// - Disk partitions and their usage
+/// 
+/// All data structures and field types match the official API specification.
+/// Note: The Storage API is marked as [UNSTABLE] in the official documentation
+/// and may change without notice in future releases.
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct OperationProgress {
+    pub done_steps: Option<i64>,
+    pub max_steps: Option<i64>,
+    pub percent: Option<i64>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct DiskPartition {
+    pub id: i64,
+    pub disk_id: i64,
+    pub state: Option<String>,
+    pub fstype: Option<String>,
+    pub label: Option<String>,
+    // path is base64 encoded mount point - not useful for metrics
+    pub total_bytes: Option<i64>,
+    pub used_bytes: Option<i64>,
+    pub free_bytes: Option<i64>,
+    pub fsck_result: Option<String>,
+    pub operation_pct: Option<OperationProgress>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct StorageDisk {
+    pub id: i64,
+    #[serde(rename = "type")]
+    pub disk_type: Option<String>,
+    pub state: Option<String>,
+    pub connector: Option<i64>,
+    pub total_bytes: Option<i64>,
+    pub table_type: Option<String>,
+    pub model: Option<String>,
+    pub serial: Option<String>,
+    pub firmware: Option<String>,
+    pub temp: Option<i64>,
+    pub operation_pct: Option<OperationProgress>,
+    pub partitions: Option<Vec<DiskPartition>>,
+    pub idle: Option<bool>,
+    pub idle_duration: Option<i64>,
+    pub spinning: Option<bool>,
+    pub active_duration: Option<i64>,
+    pub time_before_spindown: Option<i64>,
+}
+
+pub struct NasMetricMap<'a> {
+    factory: &'a AuthenticatedHttpClientFactory<'a>,
+    managed_client: Option<ManagedHttpClient>,
+    
+    // Disk metrics
+    disk_total_bytes_metric: IntGaugeVec,
+    disk_state_metric: IntGaugeVec,
+    disk_temperature_metric: IntGaugeVec,
+    disk_spinning_metric: IntGaugeVec,
+    disk_idle_metric: IntGaugeVec,
+    disk_idle_duration_metric: IntGaugeVec,
+    disk_active_duration_metric: IntGaugeVec,
+    disk_time_before_spindown_metric: IntGaugeVec,
+    disk_connector_info_metric: IntGaugeVec,
+    disk_table_type_info_metric: IntGaugeVec,
+    disk_firmware_info_metric: IntGaugeVec,
+    disk_operation_progress_metric: IntGaugeVec,
+    disk_operation_steps_metric: IntGaugeVec,
+    
+    // Partition metrics
+    partition_total_bytes_metric: IntGaugeVec,
+    partition_used_bytes_metric: IntGaugeVec,
+    partition_free_bytes_metric: IntGaugeVec,
+    partition_state_metric: IntGaugeVec,
+    partition_fsck_result_metric: IntGaugeVec,
+    partition_operation_progress_metric: IntGaugeVec,
+    partition_operation_steps_metric: IntGaugeVec,
+}
+
+impl<'a> NasMetricMap<'a> {
+    pub fn new(factory: &'a AuthenticatedHttpClientFactory<'a>, prefix: String) -> Self {
+        Self {
+            factory,
+            managed_client: None,
+            
+            // Disk metrics with labels for disk identification
+            disk_total_bytes_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_total_bytes"),
+                format!("{prefix}_nas_disk_total_bytes Total disk size in bytes"),
+                &["disk_id", "disk_type", "model", "serial"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_total_bytes gauge")),
+            
+            disk_state_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_state"),
+                format!("{prefix}_nas_disk_state Disk state (1=enabled, 0=disabled, -1=error, 2=formatting)"),
+                &["disk_id", "disk_type", "model", "serial", "state"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_state gauge")),
+            
+            disk_temperature_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_temperature_celsius"),
+                format!("{prefix}_nas_disk_temperature_celsius Disk temperature in Celsius"),
+                &["disk_id", "disk_type", "model", "serial"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_temperature_celsius gauge")),
+            
+            disk_spinning_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_spinning"),
+                format!("{prefix}_nas_disk_spinning Disk spinning status (1=spinning, 0=not spinning)"),
+                &["disk_id", "disk_type", "model", "serial"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_spinning gauge")),
+            
+            disk_idle_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_idle"),
+                format!("{prefix}_nas_disk_idle Disk idle status (1=idle, 0=active)"),
+                &["disk_id", "disk_type", "model", "serial"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_idle gauge")),
+            
+            disk_idle_duration_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_idle_duration_seconds"),
+                format!("{prefix}_nas_disk_idle_duration_seconds Disk idle duration in seconds"),
+                &["disk_id", "disk_type", "model", "serial"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_idle_duration_seconds gauge")),
+            
+            disk_active_duration_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_active_duration_seconds"),
+                format!("{prefix}_nas_disk_active_duration_seconds Disk active duration in seconds"),
+                &["disk_id", "disk_type", "model", "serial"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_active_duration_seconds gauge")),
+            
+            disk_time_before_spindown_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_time_before_spindown_seconds"),
+                format!("{prefix}_nas_disk_time_before_spindown_seconds Time before disk spindown in seconds"),
+                &["disk_id", "disk_type", "model", "serial"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_time_before_spindown_seconds gauge")),
+            
+            disk_connector_info_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_connector_info"),
+                format!("{prefix}_nas_disk_connector_info Disk physical connector ID"),
+                &["disk_id", "disk_type", "model", "serial", "connector"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_connector_info gauge")),
+            
+            disk_table_type_info_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_table_type_info"),
+                format!("{prefix}_nas_disk_table_type_info Disk partition table type"),
+                &["disk_id", "disk_type", "model", "serial", "table_type"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_table_type_info gauge")),
+            
+            disk_firmware_info_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_firmware_info"),
+                format!("{prefix}_nas_disk_firmware_info Disk firmware version"),
+                &["disk_id", "disk_type", "model", "serial", "firmware"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_firmware_info gauge")),
+            
+            disk_operation_progress_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_operation_progress_percent"),
+                format!("{prefix}_nas_disk_operation_progress_percent Disk operation progress percentage"),
+                &["disk_id", "disk_type", "model", "serial"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_operation_progress_percent gauge")),
+            
+            disk_operation_steps_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_disk_operation_steps"),
+                format!("{prefix}_nas_disk_operation_steps Disk operation steps (done/total)"),
+                &["disk_id", "disk_type", "model", "serial", "step_type"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_disk_operation_steps gauge")),
+            
+            // Partition metrics with labels for partition identification
+            partition_total_bytes_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_partition_total_bytes"),
+                format!("{prefix}_nas_partition_total_bytes Partition total size in bytes"),
+                &["partition_id", "disk_id", "label", "fstype"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_partition_total_bytes gauge")),
+            
+            partition_used_bytes_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_partition_used_bytes"),
+                format!("{prefix}_nas_partition_used_bytes Partition used space in bytes"),
+                &["partition_id", "disk_id", "label", "fstype"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_partition_used_bytes gauge")),
+            
+            partition_free_bytes_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_partition_free_bytes"),
+                format!("{prefix}_nas_partition_free_bytes Partition free space in bytes"),
+                &["partition_id", "disk_id", "label", "fstype"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_partition_free_bytes gauge")),
+            
+            partition_state_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_partition_state"),
+                format!("{prefix}_nas_partition_state Partition state (1=mounted, 0=unmounted, -1=error, 2=checking, 3=formatting, 4=mounting, 5=maintenance, 6=umounting, 7=ejecting)"),
+                &["partition_id", "disk_id", "label", "fstype", "state"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_partition_state gauge")),
+            
+            partition_fsck_result_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_partition_fsck_result"),
+                format!("{prefix}_nas_partition_fsck_result File system check result (0=no_run_yet, 1=running, 2=fs_clean, 3=fs_corrected, 4=fs_needs_correction, -1=failed)"),
+                &["partition_id", "disk_id", "label", "fstype", "fsck_result"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_partition_fsck_result gauge")),
+            
+            partition_operation_progress_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_partition_operation_progress_percent"),
+                format!("{prefix}_nas_partition_operation_progress_percent Partition operation progress percentage"),
+                &["partition_id", "disk_id", "label", "fstype"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_partition_operation_progress_percent gauge")),
+            
+            partition_operation_steps_metric: register_int_gauge_vec!(
+                format!("{prefix}_nas_partition_operation_steps"),
+                format!("{prefix}_nas_partition_operation_steps Partition operation steps (done/total)"),
+                &["partition_id", "disk_id", "label", "fstype", "step_type"]
+            )
+            .expect(&format!("cannot create {prefix}_nas_partition_operation_steps gauge")),
+        }
+    }
+
+    async fn get_managed_client(
+        &mut self,
+    ) -> Result<Client, Box<dyn std::error::Error + Send + Sync>> {
+        if self.managed_client.as_ref().is_none() {
+            debug!("creating managed client");
+
+            let res = self.factory.create_managed_client().await;
+
+            if res.is_err() {
+                debug!("cannot create managed client");
+                return Err(res.err().unwrap());
+            }
+
+            self.managed_client = Some(res.unwrap());
+        }
+
+        let client = self.managed_client.as_ref().clone().unwrap();
+        let res = client.get();
+
+        if res.is_ok() {
+            return Ok(res.unwrap());
+        } else {
+            debug!("renewing managed client");
+
+            let client = self.factory.create_managed_client().await;
+            self.managed_client = Some(client.unwrap());
+
+            return self.managed_client.as_ref().unwrap().get();
+        }
+    }
+
+    fn reset_all(&mut self) {
+        self.disk_total_bytes_metric.reset();
+        self.disk_state_metric.reset();
+        self.disk_temperature_metric.reset();
+        self.disk_spinning_metric.reset();
+        self.disk_idle_metric.reset();
+        self.disk_idle_duration_metric.reset();
+        self.disk_active_duration_metric.reset();
+        self.disk_time_before_spindown_metric.reset();
+        self.disk_connector_info_metric.reset();
+        self.disk_table_type_info_metric.reset();
+        self.disk_firmware_info_metric.reset();
+        self.disk_operation_progress_metric.reset();
+        self.disk_operation_steps_metric.reset();
+        self.partition_total_bytes_metric.reset();
+        self.partition_used_bytes_metric.reset();
+        self.partition_free_bytes_metric.reset();
+        self.partition_state_metric.reset();
+        self.partition_fsck_result_metric.reset();
+        self.partition_operation_progress_metric.reset();
+        self.partition_operation_steps_metric.reset();
+    }
+
+    async fn set_storage_metrics(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        debug!("fetching storage disks");
+
+        let body = self
+            .get_managed_client()
+            .await
+            .unwrap()
+            .get(format!("{}v4/storage/disk", self.factory.api_url))
+            .send()
+            .await?
+            .text()
+            .await?;
+
+        let res = match serde_json::from_str::<FreeboxResponse<Vec<StorageDisk>>>(&body) {
+            Err(e) => return Err(Box::new(e)),
+            Ok(r) => r,
+        };
+
+        if !res.success.unwrap_or(false) {
+            return Err(Box::new(FreeboxResponseError::new(
+                res.msg.unwrap_or_default(),
+            )));
+        }
+
+        let disks: Vec<StorageDisk> = match res.result {
+            None => {
+                return Err(Box::new(FreeboxResponseError::new(
+                    "v4/storage/disk response was empty".to_string(),
+                )))
+            }
+            Some(r) => r,
+        };
+
+        for disk in disks {
+            let disk_id = disk.id.to_string();
+            let disk_type = disk.disk_type.unwrap_or_else(|| "unknown".to_string());
+            let model = disk.model.unwrap_or_else(|| "unknown".to_string());
+            let serial = disk.serial.unwrap_or_else(|| "unknown".to_string());
+            
+            // Set disk metrics
+            if let Some(total_bytes) = disk.total_bytes {
+                self.disk_total_bytes_metric
+                    .with_label_values(&[&disk_id, &disk_type, &model, &serial])
+                    .set(total_bytes);
+            }
+
+            // Map disk state to numeric value according to API spec
+            let state_value = match disk.state.as_deref() {
+                Some("enabled") => 1,
+                Some("disabled") => 0,
+                Some("error") => -1,
+                Some("formatting") => 2,
+                _ => 0,
+            };
+            let state = disk.state.unwrap_or_else(|| "unknown".to_string());
+            self.disk_state_metric
+                .with_label_values(&[&disk_id, &disk_type, &model, &serial, &state])
+                .set(state_value);
+
+            if let Some(temp) = disk.temp {
+                self.disk_temperature_metric
+                    .with_label_values(&[&disk_id, &disk_type, &model, &serial])
+                    .set(temp);
+            }
+
+            if let Some(spinning) = disk.spinning {
+                self.disk_spinning_metric
+                    .with_label_values(&[&disk_id, &disk_type, &model, &serial])
+                    .set(if spinning { 1 } else { 0 });
+            }
+
+            if let Some(idle) = disk.idle {
+                self.disk_idle_metric
+                    .with_label_values(&[&disk_id, &disk_type, &model, &serial])
+                    .set(if idle { 1 } else { 0 });
+            }
+
+            if let Some(idle_duration) = disk.idle_duration {
+                self.disk_idle_duration_metric
+                    .with_label_values(&[&disk_id, &disk_type, &model, &serial])
+                    .set(idle_duration);
+            }
+
+            if let Some(active_duration) = disk.active_duration {
+                self.disk_active_duration_metric
+                    .with_label_values(&[&disk_id, &disk_type, &model, &serial])
+                    .set(active_duration);
+            }
+
+            if let Some(time_before_spindown) = disk.time_before_spindown {
+                self.disk_time_before_spindown_metric
+                    .with_label_values(&[&disk_id, &disk_type, &model, &serial])
+                    .set(time_before_spindown);
+            }
+
+            // Set connector information
+            if let Some(connector) = disk.connector {
+                self.disk_connector_info_metric
+                    .with_label_values(&[&disk_id, &disk_type, &model, &serial, &connector.to_string()])
+                    .set(1);
+            }
+
+            // Set table type information
+            if let Some(table_type) = &disk.table_type {
+                self.disk_table_type_info_metric
+                    .with_label_values(&[&disk_id, &disk_type, &model, &serial, table_type])
+                    .set(1);
+            }
+
+            // Set firmware information
+            if let Some(firmware) = &disk.firmware {
+                if !firmware.is_empty() {
+                    self.disk_firmware_info_metric
+                        .with_label_values(&[&disk_id, &disk_type, &model, &serial, firmware])
+                        .set(1);
+                }
+            }
+
+            // Set disk operation progress
+            if let Some(operation_pct) = &disk.operation_pct {
+                if let Some(percent) = operation_pct.percent {
+                    self.disk_operation_progress_metric
+                        .with_label_values(&[&disk_id, &disk_type, &model, &serial])
+                        .set(percent);
+                }
+                
+                // Set disk operation steps (done/total)
+                if let Some(done_steps) = operation_pct.done_steps {
+                    self.disk_operation_steps_metric
+                        .with_label_values(&[&disk_id, &disk_type, &model, &serial, "done"])
+                        .set(done_steps);
+                }
+                
+                if let Some(max_steps) = operation_pct.max_steps {
+                    self.disk_operation_steps_metric
+                        .with_label_values(&[&disk_id, &disk_type, &model, &serial, "total"])
+                        .set(max_steps);
+                }
+            }
+
+            // Process partitions
+            if let Some(partitions) = disk.partitions {
+                for partition in partitions {
+                    let partition_id = partition.id.to_string();
+                    let partition_disk_id = partition.disk_id.to_string();
+                    let label = partition.label.unwrap_or_else(|| "unknown".to_string());
+                    let fstype = partition.fstype.unwrap_or_else(|| "unknown".to_string());
+
+                    if let Some(total_bytes) = partition.total_bytes {
+                        self.partition_total_bytes_metric
+                            .with_label_values(&[&partition_id, &partition_disk_id, &label, &fstype])
+                            .set(total_bytes);
+                    }
+
+                    if let Some(used_bytes) = partition.used_bytes {
+                        self.partition_used_bytes_metric
+                            .with_label_values(&[&partition_id, &partition_disk_id, &label, &fstype])
+                            .set(used_bytes);
+                    }
+
+                    if let Some(free_bytes) = partition.free_bytes {
+                        self.partition_free_bytes_metric
+                            .with_label_values(&[&partition_id, &partition_disk_id, &label, &fstype])
+                            .set(free_bytes);
+                    }
+
+                    // Map partition state to numeric value according to API spec
+                    let partition_state_value = match partition.state.as_deref() {
+                        Some("mounted") => 1,
+                        Some("umounted") => 0,
+                        Some("error") => -1,
+                        Some("checking") => 2,
+                        Some("formatting") => 3,
+                        Some("mounting") => 4,
+                        Some("maintenance") => 5,
+                        Some("umounting") => 6,
+                        Some("ejecting") => 7,
+                        _ => 0,
+                    };
+                    let partition_state = partition.state.unwrap_or_else(|| "unknown".to_string());
+                    self.partition_state_metric
+                        .with_label_values(&[&partition_id, &partition_disk_id, &label, &fstype, &partition_state])
+                        .set(partition_state_value);
+
+                    // Set fsck result
+                    if let Some(fsck_result) = &partition.fsck_result {
+                        let fsck_result_value = match fsck_result.as_str() {
+                            "no_run_yet" => 0,
+                            "running" => 1,
+                            "fs_clean" => 2,
+                            "fs_corrected" => 3,
+                            "fs_needs_correction" => 4,
+                            "failed" => -1,
+                            _ => 0,
+                        };
+                        self.partition_fsck_result_metric
+                            .with_label_values(&[&partition_id, &partition_disk_id, &label, &fstype, fsck_result])
+                            .set(fsck_result_value);
+                    }
+
+                    // Set partition operation progress
+                    if let Some(operation_pct) = &partition.operation_pct {
+                        if let Some(percent) = operation_pct.percent {
+                            self.partition_operation_progress_metric
+                                .with_label_values(&[&partition_id, &partition_disk_id, &label, &fstype])
+                                .set(percent);
+                        }
+                        
+                        // Set partition operation steps (done/total)
+                        if let Some(done_steps) = operation_pct.done_steps {
+                            self.partition_operation_steps_metric
+                                .with_label_values(&[&partition_id, &partition_disk_id, &label, &fstype, "done"])
+                                .set(done_steps);
+                        }
+                        
+                        if let Some(max_steps) = operation_pct.max_steps {
+                            self.partition_operation_steps_metric
+                                .with_label_values(&[&partition_id, &partition_disk_id, &label, &fstype, "total"])
+                                .set(max_steps);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<'a> MetricMap<'a> for NasMetricMap<'a> {
+    async fn init(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Ok(())
+    }
+
+    async fn set(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.reset_all();
+
+        match self.set_storage_metrics().await {
+            Err(e) => return Err(e),
+            _ => {}
+        };
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_storage_disk_deserialize() {
+        // Based on official API documentation example response
+        let json_data = r#"{
+            "idle_duration": 368,
+            "spinning": true,
+            "table_type": "msdos",
+            "firmware": "PB2ICC0E",
+            "type": "internal",
+            "idle": true,
+            "connector": 0,
+            "id": 1,
+            "state": "enabled",
+            "time_before_spindown": 232,
+            "total_bytes": 250059350016,
+            "model": "Hitachi HCC545025B9A300",
+            "active_duration": 0,
+            "temp": 51,
+            "serial": "GSCH35VC",
+            "partitions": [
+                {
+                    "fstype": "ext4",
+                    "total_bytes": 245091500032,
+                    "label": "Disque dur",
+                    "id": 3,
+                    "fsck_result": "no_run_yet",
+                    "state": "mounted",
+                    "disk_id": 1,
+                    "free_bytes": 68120969216,
+                    "used_bytes": 164520534016,
+                    "path": "L0Rpc3F1ZSBkdXI="
+                }
+            ]
+        }"#;
+
+        let disk: StorageDisk = serde_json::from_str(json_data).unwrap();
+
+        assert_eq!(disk.id, 1);
+        assert_eq!(disk.disk_type.unwrap(), "internal");
+        assert_eq!(disk.state.unwrap(), "enabled");
+        assert_eq!(disk.total_bytes.unwrap(), 250059350016);
+        assert_eq!(disk.temp.unwrap(), 51);
+        assert_eq!(disk.idle.unwrap(), true);
+        assert_eq!(disk.spinning.unwrap(), true);
+        assert_eq!(disk.table_type.unwrap(), "msdos");
+        assert_eq!(disk.model.unwrap(), "Hitachi HCC545025B9A300");
+        assert_eq!(disk.serial.unwrap(), "GSCH35VC");
+        assert_eq!(disk.firmware.unwrap(), "PB2ICC0E");
+        assert_eq!(disk.idle_duration.unwrap(), 368);
+        assert_eq!(disk.active_duration.unwrap(), 0);
+        assert_eq!(disk.time_before_spindown.unwrap(), 232);
+
+        let partitions = disk.partitions.unwrap();
+        assert_eq!(partitions.len(), 1);
+        
+        let partition = &partitions[0];
+        assert_eq!(partition.id, 3);
+        assert_eq!(partition.disk_id, 1);
+        assert_eq!(partition.state.as_ref().unwrap(), "mounted");
+        assert_eq!(partition.fstype.as_ref().unwrap(), "ext4");
+        assert_eq!(partition.label.as_ref().unwrap(), "Disque dur");
+        assert_eq!(partition.total_bytes.unwrap(), 245091500032);
+        assert_eq!(partition.used_bytes.unwrap(), 164520534016);
+        assert_eq!(partition.free_bytes.unwrap(), 68120969216);
+        assert_eq!(partition.fsck_result.as_ref().unwrap(), "no_run_yet");
+    }
+
+    #[test]
+    fn test_storage_disk_deserialize_usb() {
+        // Based on official API documentation example response
+        let json_data = r#"{
+            "type": "usb",
+            "total_bytes": 125435904,
+            "connector": 1,
+            "id": 1001,
+            "active_duration": 0,
+            "partitions": [
+                {
+                    "fstype": "ext4",
+                    "total_bytes": 121418752,
+                    "label": "Disque 1",
+                    "id": 1002,
+                    "fsck_result": "no_run_yet",
+                    "state": "mounted",
+                    "disk_id": 1001,
+                    "free_bytes": 108904448,
+                    "used_bytes": 6245376,
+                    "path": "L0Rpc3F1ZSAx"
+                }
+            ],
+            "idle_duration": 0,
+            "state": "enabled",
+            "idle": false,
+            "spinning": false,
+            "model": "",
+            "table_type": "gpt",
+            "temp": 0,
+            "serial": "",
+            "firmware": ""
+        }"#;
+
+        let disk: StorageDisk = serde_json::from_str(json_data).unwrap();
+
+        assert_eq!(disk.id, 1001);
+        assert_eq!(disk.disk_type.unwrap(), "usb");
+        assert_eq!(disk.state.unwrap(), "enabled");
+        assert_eq!(disk.total_bytes.unwrap(), 125435904);
+        assert_eq!(disk.temp.unwrap(), 0);
+        assert_eq!(disk.idle.unwrap(), false);
+        assert_eq!(disk.spinning.unwrap(), false);
+        assert_eq!(disk.table_type.unwrap(), "gpt");
+        assert_eq!(disk.model.unwrap(), "");
+        assert_eq!(disk.serial.unwrap(), "");
+        assert_eq!(disk.firmware.unwrap(), "");
+        assert_eq!(disk.idle_duration.unwrap(), 0);
+        assert_eq!(disk.active_duration.unwrap(), 0);
+
+        let partitions = disk.partitions.unwrap();
+        assert_eq!(partitions.len(), 1);
+        
+        let partition = &partitions[0];
+        assert_eq!(partition.id, 1002);
+        assert_eq!(partition.disk_id, 1001);
+        assert_eq!(partition.state.as_ref().unwrap(), "mounted");
+        assert_eq!(partition.fstype.as_ref().unwrap(), "ext4");
+        assert_eq!(partition.label.as_ref().unwrap(), "Disque 1");
+        assert_eq!(partition.total_bytes.unwrap(), 121418752);
+        assert_eq!(partition.used_bytes.unwrap(), 6245376);
+        assert_eq!(partition.free_bytes.unwrap(), 108904448);
+        assert_eq!(partition.fsck_result.as_ref().unwrap(), "no_run_yet");
+    }
+
+    #[test]
+    fn test_disk_partition_deserialize() {
+        // Based on official API documentation example response for partition API
+        let json_data = r#"{
+            "fstype": "vfat",
+            "total_bytes": 123485184,
+            "label": "freebox",
+            "id": 1002,
+            "fsck_result": "no_run_yet",
+            "state": "mounted",
+            "disk_id": 1001,
+            "free_bytes": 123484672,
+            "used_bytes": 512,
+            "path": "L2ZyZWVib3g="
+        }"#;
+
+        let partition: DiskPartition = serde_json::from_str(json_data).unwrap();
+
+        assert_eq!(partition.id, 1002);
+        assert_eq!(partition.disk_id, 1001);
+        assert_eq!(partition.state.as_ref().unwrap(), "mounted");
+        assert_eq!(partition.fstype.as_ref().unwrap(), "vfat");
+        assert_eq!(partition.label.as_ref().unwrap(), "freebox");
+        assert_eq!(partition.total_bytes.unwrap(), 123485184);
+        assert_eq!(partition.used_bytes.unwrap(), 512);
+        assert_eq!(partition.free_bytes.unwrap(), 123484672);
+        assert_eq!(partition.fsck_result.as_ref().unwrap(), "no_run_yet");
+    }
+}


### PR DESCRIPTION
This pull request introduces support for NAS (Network Attached Storage) metrics in the Freebox exporter. It adds configuration and documentation for enabling NAS metrics, updates the capabilities and configuration structures, and integrates the new NAS metrics into the metric mapping system. The version is also bumped to reflect these new features.

**NAS Metrics Support**

* Added NAS metrics support, exposing detailed disk and partition information via the Freebox Storage API. This includes metrics for storage capacity, disk state, temperature, power management, hardware and physical info, performance, and partition usage and health. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R112-R152) [[2]](diffhunk://#diff-5fb47a797c6d434cf0bf139c8ae08fe1afea49bbc85afd67e236220a9bb60ac7R23)
* Updated documentation (`README.md`) to describe the new NAS metrics, configuration options, and example output. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R112-R152) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R207-R208)
* Updated example configuration files to include the new `nas = true` option.

**Capabilities and Configuration Updates**

* Added `nas` field to capabilities and configuration structs, and ensured it is always available in the capabilities agent. [[1]](diffhunk://#diff-cd304bed49233688fdbe72c4acd2eee82c778db496192e8532bc736e63e187a2R69) [[2]](diffhunk://#diff-cd304bed49233688fdbe72c4acd2eee82c778db496192e8532bc736e63e187a2R111) [[3]](diffhunk://#diff-b2e59f90eb631494642611b6161e0ec9fb741140ebe20bbde559a90951dc1ba1R28)
* Updated configuration tests to include the new `nas` field and adjusted expected values accordingly. [[1]](diffhunk://#diff-b2fceece3c9282aa39715959600f3cfb163d8e449afcd2541d1438bbbe45cdf2R112) [[2]](diffhunk://#diff-b2fceece3c9282aa39715959600f3cfb163d8e449afcd2541d1438bbbe45cdf2R140) [[3]](diffhunk://#diff-b2fceece3c9282aa39715959600f3cfb163d8e449afcd2541d1438bbbe45cdf2R168) [[4]](diffhunk://#diff-b2fceece3c9282aa39715959600f3cfb163d8e449afcd2541d1438bbbe45cdf2R203) [[5]](diffhunk://#diff-b2fceece3c9282aa39715959600f3cfb163d8e449afcd2541d1438bbbe45cdf2L221-R231) [[6]](diffhunk://#diff-b2fceece3c9282aa39715959600f3cfb163d8e449afcd2541d1438bbbe45cdf2L248-R259)

**Metric Mapping Integration**

* Integrated NAS metrics into the main metric mapping logic, including checks for configuration and capability compatibility, and added warnings for missing or incompatible NAS configuration. [[1]](diffhunk://#diff-5fb47a797c6d434cf0bf139c8ae08fe1afea49bbc85afd67e236220a9bb60ac7R7) [[2]](diffhunk://#diff-5fb47a797c6d434cf0bf139c8ae08fe1afea49bbc85afd67e236220a9bb60ac7R156-R170)

**Other Changes**

* Bumped the crate version to `0.0.25` to reflect the new feature.
* Minor cleanup in CLI and configuration code. [[1]](diffhunk://#diff-4fe28f1e1072a7a95651671f8e6fc26558e9e72ec798fde5c83dcbc0b17b3091L1-R1) [[2]](diffhunk://#diff-b2e59f90eb631494642611b6161e0ec9fb741140ebe20bbde559a90951dc1ba1L19)