### PR TITLE
feat(metrics): add Freebox download stats exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,36 @@ fbx_exporter_nas_disk_temperature_celsius{disk_id="1",disk_type="internal",model
 fbx_exporter_nas_partition_used_bytes{partition_id="3",disk_id="1",label="Disque dur",fstype="ext4"} 164520534016
 ```
 
+## Download Metrics
+
+The exporter can expose global downloader statistics from Freebox OS Download API endpoint `/api/v4/downloads/stats`.
+
+### Configuration
+
+Enable Download metrics by setting `download = true` in your configuration file:
+
+```toml
+[metrics]
+download = true
+```
+
+### Exposed Metrics
+
+- **Traffic**: current downloader RX/TX rate in bytes per second
+- **Tasks**: total tasks and per-state counters (active, downloading, seeding, queued, stopped, checking, extracting, done, repairing, error, stopping)
+- **Downloader state**: connection readiness, peer count, unread RSS items
+- **Throttling**: current mode, schedule flag, and throttling RX/TX rates
+
+Example metrics exposed:
+```
+fbx_exporter_download_rx_rate_bytes_per_second 14222
+fbx_exporter_download_tx_rate_bytes_per_second 4294
+fbx_exporter_download_tasks_active 11
+fbx_exporter_download_tasks_downloading 4
+fbx_exporter_download_tasks_stopped 1
+fbx_exporter_download_throttling_mode_info{mode="normal"} 1
+```
+
 ## Running project
 
 Running with docker
@@ -206,6 +236,8 @@ dhcp = true
 system = true
 # Exposes NAS storage information (disks and partitions)
 nas = true
+# Exposes global downloader statistics (/api/v4/downloads/stats)
+download = true
 # Sets metrics prefix, it cannot be empty
 # Warning if you are using the exporter Grafana board, changing this value will cause the board to be unable to retrieve data if you do not update it
 prefix = "fbx_exporter"

--- a/config.toml
+++ b/config.toml
@@ -23,6 +23,8 @@ dhcp = true
 system = true
 # Exposes NAS storage information (disks and partitions)
 nas = true
+# Exposes global downloader statistics (/api/v4/downloads/stats)
+download = true
 # Sets metrics prefix, it cannot be empty
 # Warning if you are using the exporter Grafana board, changing this value will cause the board to be unable to retrieve data if you do not update it
 prefix = "fbx_exporter"

--- a/grafana-board.json
+++ b/grafana-board.json
@@ -6690,6 +6690,591 @@
       ],
       "title": "Disk Active Duration",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 149
+      },
+      "id": 63,
+      "panels": [],
+      "title": "Download",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 120000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 150
+      },
+      "id": 64,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_rx_rate_bytes_per_second{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "download rx",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_tx_rate_bytes_per_second{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "download tx",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Download Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 120000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 150
+      },
+      "id": 65,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_tasks_active{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "active",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_tasks_downloading{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "downloading",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_tasks_seeding{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "seeding",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_tasks_stopped{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "stopped",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_tasks_queued{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "queued",
+          "range": true,
+          "refId": "E",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_tasks_error{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "error",
+          "range": true,
+          "refId": "F",
+          "useBackend": false
+        }
+      ],
+      "title": "Download Tasks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 120000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 158
+      },
+      "id": 66,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_throttling_rx_rate_bytes_per_second{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "throttling rx",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_throttling_tx_rate_bytes_per_second{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "throttling tx",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Download Throttling Rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 120000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 158
+      },
+      "id": 67,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_peers_total{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "peers",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_rss_items_unread{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "rss unread",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_connection_ready{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "connection ready",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "fbx_exporter_download_throttling_is_scheduled{instance=\"$node\", job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "throttling scheduled",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        }
+      ],
+      "title": "Download Status",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",
@@ -6804,6 +7389,6 @@
   "timezone": "browser",
   "title": "freebox-exporter-rs",
   "uid": "deddg8kngnmyoa",
-  "version": 28,
+  "version": 29,
   "weekStart": ""
 }

--- a/src/core/configuration/sections.rs
+++ b/src/core/configuration/sections.rs
@@ -26,6 +26,7 @@ pub struct CapabilitiesConfiguration {
     pub wifi: Option<bool>,
     pub dhcp: Option<bool>,
     pub nas: Option<bool>,
+    pub download: Option<bool>,
     pub prefix: Option<String>,
 }
 

--- a/src/core/configuration/tests.rs
+++ b/src/core/configuration/tests.rs
@@ -34,6 +34,7 @@ lan = true
 lan_browser = true
 switch = true
 wifi = true
+download = true
 system = false
 prefix = \"fbx\"
 
@@ -77,6 +78,7 @@ unresolved_station_hostnames = \"ignore\"";
         assert_eq!(true, conf.metrics.lan_browser.unwrap());
         assert_eq!(true, conf.metrics.switch.unwrap());
         assert_eq!(true, conf.metrics.wifi.unwrap());
+        assert_eq!(true, conf.metrics.download.unwrap());
         assert_eq!(false, conf.metrics.system.unwrap());
         assert_eq!("fbx", conf.metrics.prefix.unwrap());
 
@@ -110,6 +112,7 @@ unresolved_station_hostnames = \"ignore\"";
                 wifi: None,
                 dhcp: None,
                 nas: None,
+                download: None,
             },
             policies: Some(PoliciesConfiguration {
                 unresolved_station_hostnames: None,
@@ -138,6 +141,7 @@ unresolved_station_hostnames = \"ignore\"";
                 wifi: None,
                 dhcp: None,
                 nas: None,
+                download: None,
             },
             policies: Some(PoliciesConfiguration {
                 unresolved_station_hostnames: None,
@@ -166,6 +170,7 @@ unresolved_station_hostnames = \"ignore\"";
                 wifi: None,
                 dhcp: None,
                 nas: None,
+                download: None,
             },
             policies: Some(PoliciesConfiguration {
                 unresolved_station_hostnames: None,
@@ -201,6 +206,7 @@ unresolved_station_hostnames = \"ignore\"";
                 wifi: None,
                 dhcp: None,
                 nas: None,
+                download: None,
             },
             policies: Some(PoliciesConfiguration {
                 unresolved_station_hostnames: None,
@@ -229,6 +235,7 @@ unresolved_station_hostnames = \"ignore\"";
                 wifi: None,
                 dhcp: None,
                 nas: None,
+                download: None,
             },
             policies: Some(PoliciesConfiguration {
                 unresolved_station_hostnames: None,
@@ -257,6 +264,7 @@ unresolved_station_hostnames = \"ignore\"";
                 wifi: None,
                 dhcp: None,
                 nas: None,
+                download: None,
             },
             policies: Some(PoliciesConfiguration {
                 unresolved_station_hostnames: None,

--- a/src/mappers/download.rs
+++ b/src/mappers/download.rs
@@ -1,0 +1,374 @@
+use async_trait::async_trait;
+use log::debug;
+use prometheus_exporter::prometheus::{register_int_gauge, register_int_gauge_vec, IntGauge, IntGaugeVec};
+use reqwest::Client;
+use serde::Deserialize;
+
+use super::MetricMap;
+use crate::core::common::{
+    http_client_factory::{AuthenticatedHttpClientFactory, ManagedHttpClient},
+    transport::{FreeboxResponse, FreeboxResponseError},
+};
+
+#[derive(Deserialize, Clone, Debug)]
+struct DlRate {
+    rx_rate: Option<i64>,
+    tx_rate: Option<i64>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+struct DownloadStats {
+    nb_tasks: Option<i64>,
+    nb_tasks_stopped: Option<i64>,
+    nb_tasks_checking: Option<i64>,
+    nb_tasks_queued: Option<i64>,
+    nb_tasks_extracting: Option<i64>,
+    nb_tasks_done: Option<i64>,
+    nb_tasks_repairing: Option<i64>,
+    nb_tasks_seeding: Option<i64>,
+    nb_tasks_downloading: Option<i64>,
+    nb_tasks_error: Option<i64>,
+    nb_tasks_stopping: Option<i64>,
+    nb_tasks_active: Option<i64>,
+    nb_rss_items_unread: Option<i64>,
+    rx_rate: Option<i64>,
+    tx_rate: Option<i64>,
+    throttling_mode: Option<String>,
+    throttling_is_scheduled: Option<bool>,
+    throttling_rate: Option<DlRate>,
+    conn_ready: Option<bool>,
+    nb_peer: Option<i64>,
+}
+
+pub struct DownloadMetricMap<'a> {
+    factory: &'a AuthenticatedHttpClientFactory<'a>,
+    managed_client: Option<ManagedHttpClient>,
+    rx_rate_metric: IntGauge,
+    tx_rate_metric: IntGauge,
+    nb_tasks_metric: IntGauge,
+    nb_tasks_active_metric: IntGauge,
+    nb_tasks_downloading_metric: IntGauge,
+    nb_tasks_seeding_metric: IntGauge,
+    nb_tasks_stopped_metric: IntGauge,
+    nb_tasks_queued_metric: IntGauge,
+    nb_tasks_checking_metric: IntGauge,
+    nb_tasks_extracting_metric: IntGauge,
+    nb_tasks_done_metric: IntGauge,
+    nb_tasks_repairing_metric: IntGauge,
+    nb_tasks_error_metric: IntGauge,
+    nb_tasks_stopping_metric: IntGauge,
+    nb_rss_items_unread_metric: IntGauge,
+    nb_peer_metric: IntGauge,
+    conn_ready_metric: IntGauge,
+    throttling_is_scheduled_metric: IntGauge,
+    throttling_mode_metric: IntGaugeVec,
+    throttling_rx_rate_metric: IntGauge,
+    throttling_tx_rate_metric: IntGauge,
+}
+
+impl<'a> DownloadMetricMap<'a> {
+    pub fn new(factory: &'a AuthenticatedHttpClientFactory<'a>, prefix: String) -> Self {
+        Self {
+            factory,
+            managed_client: None,
+            rx_rate_metric: register_int_gauge!(
+                format!("{prefix}_download_rx_rate_bytes_per_second"),
+                format!("{prefix}_download_rx_rate_bytes_per_second")
+            )
+            .expect(&format!(
+                "cannot create {prefix}_download_rx_rate_bytes_per_second gauge"
+            )),
+            tx_rate_metric: register_int_gauge!(
+                format!("{prefix}_download_tx_rate_bytes_per_second"),
+                format!("{prefix}_download_tx_rate_bytes_per_second")
+            )
+            .expect(&format!(
+                "cannot create {prefix}_download_tx_rate_bytes_per_second gauge"
+            )),
+            nb_tasks_metric: register_int_gauge!(
+                format!("{prefix}_download_tasks_total"),
+                format!("{prefix}_download_tasks_total")
+            )
+            .expect(&format!("cannot create {prefix}_download_tasks_total gauge")),
+            nb_tasks_active_metric: register_int_gauge!(
+                format!("{prefix}_download_tasks_active"),
+                format!("{prefix}_download_tasks_active")
+            )
+            .expect(&format!("cannot create {prefix}_download_tasks_active gauge")),
+            nb_tasks_downloading_metric: register_int_gauge!(
+                format!("{prefix}_download_tasks_downloading"),
+                format!("{prefix}_download_tasks_downloading")
+            )
+            .expect(&format!("cannot create {prefix}_download_tasks_downloading gauge")),
+            nb_tasks_seeding_metric: register_int_gauge!(
+                format!("{prefix}_download_tasks_seeding"),
+                format!("{prefix}_download_tasks_seeding")
+            )
+            .expect(&format!("cannot create {prefix}_download_tasks_seeding gauge")),
+            nb_tasks_stopped_metric: register_int_gauge!(
+                format!("{prefix}_download_tasks_stopped"),
+                format!("{prefix}_download_tasks_stopped")
+            )
+            .expect(&format!("cannot create {prefix}_download_tasks_stopped gauge")),
+            nb_tasks_queued_metric: register_int_gauge!(
+                format!("{prefix}_download_tasks_queued"),
+                format!("{prefix}_download_tasks_queued")
+            )
+            .expect(&format!("cannot create {prefix}_download_tasks_queued gauge")),
+            nb_tasks_checking_metric: register_int_gauge!(
+                format!("{prefix}_download_tasks_checking"),
+                format!("{prefix}_download_tasks_checking")
+            )
+            .expect(&format!("cannot create {prefix}_download_tasks_checking gauge")),
+            nb_tasks_extracting_metric: register_int_gauge!(
+                format!("{prefix}_download_tasks_extracting"),
+                format!("{prefix}_download_tasks_extracting")
+            )
+            .expect(&format!("cannot create {prefix}_download_tasks_extracting gauge")),
+            nb_tasks_done_metric: register_int_gauge!(
+                format!("{prefix}_download_tasks_done"),
+                format!("{prefix}_download_tasks_done")
+            )
+            .expect(&format!("cannot create {prefix}_download_tasks_done gauge")),
+            nb_tasks_repairing_metric: register_int_gauge!(
+                format!("{prefix}_download_tasks_repairing"),
+                format!("{prefix}_download_tasks_repairing")
+            )
+            .expect(&format!("cannot create {prefix}_download_tasks_repairing gauge")),
+            nb_tasks_error_metric: register_int_gauge!(
+                format!("{prefix}_download_tasks_error"),
+                format!("{prefix}_download_tasks_error")
+            )
+            .expect(&format!("cannot create {prefix}_download_tasks_error gauge")),
+            nb_tasks_stopping_metric: register_int_gauge!(
+                format!("{prefix}_download_tasks_stopping"),
+                format!("{prefix}_download_tasks_stopping")
+            )
+            .expect(&format!("cannot create {prefix}_download_tasks_stopping gauge")),
+            nb_rss_items_unread_metric: register_int_gauge!(
+                format!("{prefix}_download_rss_items_unread"),
+                format!("{prefix}_download_rss_items_unread")
+            )
+            .expect(&format!("cannot create {prefix}_download_rss_items_unread gauge")),
+            nb_peer_metric: register_int_gauge!(
+                format!("{prefix}_download_peers_total"),
+                format!("{prefix}_download_peers_total")
+            )
+            .expect(&format!("cannot create {prefix}_download_peers_total gauge")),
+            conn_ready_metric: register_int_gauge!(
+                format!("{prefix}_download_connection_ready"),
+                format!("{prefix}_download_connection_ready")
+            )
+            .expect(&format!("cannot create {prefix}_download_connection_ready gauge")),
+            throttling_is_scheduled_metric: register_int_gauge!(
+                format!("{prefix}_download_throttling_is_scheduled"),
+                format!("{prefix}_download_throttling_is_scheduled")
+            )
+            .expect(&format!(
+                "cannot create {prefix}_download_throttling_is_scheduled gauge"
+            )),
+            throttling_mode_metric: register_int_gauge_vec!(
+                format!("{prefix}_download_throttling_mode_info"),
+                format!("{prefix}_download_throttling_mode_info"),
+                &["mode"]
+            )
+            .expect(&format!(
+                "cannot create {prefix}_download_throttling_mode_info gauge"
+            )),
+            throttling_rx_rate_metric: register_int_gauge!(
+                format!("{prefix}_download_throttling_rx_rate_bytes_per_second"),
+                format!("{prefix}_download_throttling_rx_rate_bytes_per_second")
+            )
+            .expect(&format!(
+                "cannot create {prefix}_download_throttling_rx_rate_bytes_per_second gauge"
+            )),
+            throttling_tx_rate_metric: register_int_gauge!(
+                format!("{prefix}_download_throttling_tx_rate_bytes_per_second"),
+                format!("{prefix}_download_throttling_tx_rate_bytes_per_second")
+            )
+            .expect(&format!(
+                "cannot create {prefix}_download_throttling_tx_rate_bytes_per_second gauge"
+            )),
+        }
+    }
+
+    async fn get_managed_client(
+        &mut self,
+    ) -> Result<Client, Box<dyn std::error::Error + Send + Sync>> {
+        if self.managed_client.as_ref().is_none() {
+            debug!("creating managed client");
+
+            let res = self.factory.create_managed_client().await;
+
+            if res.is_err() {
+                debug!("cannot create managed client");
+                return Err(res.err().unwrap());
+            }
+
+            self.managed_client = Some(res.unwrap());
+        }
+
+        let client = self.managed_client.as_ref().clone().unwrap();
+        let res = client.get();
+
+        if res.is_ok() {
+            return Ok(res.unwrap());
+        } else {
+            debug!("renewing managed client");
+
+            let client = self.factory.create_managed_client().await;
+            self.managed_client = Some(client.unwrap());
+
+            return self.managed_client.as_ref().unwrap().get();
+        }
+    }
+
+    async fn set_download_metrics(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let body = self
+            .get_managed_client()
+            .await?
+            .get(format!("{}v4/downloads/stats", self.factory.api_url))
+            .send()
+            .await?
+            .text()
+            .await?;
+
+        let res = match serde_json::from_str::<FreeboxResponse<DownloadStats>>(&body) {
+            Err(e) => return Err(Box::new(e)),
+            Ok(r) => r,
+        };
+
+        if !res.success.unwrap_or(false) {
+            return Err(Box::new(FreeboxResponseError::new(
+                res.msg.unwrap_or_default(),
+            )));
+        }
+
+        let stats = match res.result {
+            Some(s) => s,
+            None => {
+                return Err(Box::new(FreeboxResponseError::new(
+                    "v4/downloads/stats response was empty".to_string(),
+                )))
+            }
+        };
+
+        self.rx_rate_metric.set(stats.rx_rate.unwrap_or_default());
+        self.tx_rate_metric.set(stats.tx_rate.unwrap_or_default());
+        self.nb_tasks_metric.set(stats.nb_tasks.unwrap_or_default());
+        self.nb_tasks_active_metric
+            .set(stats.nb_tasks_active.unwrap_or_default());
+        self.nb_tasks_downloading_metric
+            .set(stats.nb_tasks_downloading.unwrap_or_default());
+        self.nb_tasks_seeding_metric
+            .set(stats.nb_tasks_seeding.unwrap_or_default());
+        self.nb_tasks_stopped_metric
+            .set(stats.nb_tasks_stopped.unwrap_or_default());
+        self.nb_tasks_queued_metric
+            .set(stats.nb_tasks_queued.unwrap_or_default());
+        self.nb_tasks_checking_metric
+            .set(stats.nb_tasks_checking.unwrap_or_default());
+        self.nb_tasks_extracting_metric
+            .set(stats.nb_tasks_extracting.unwrap_or_default());
+        self.nb_tasks_done_metric
+            .set(stats.nb_tasks_done.unwrap_or_default());
+        self.nb_tasks_repairing_metric
+            .set(stats.nb_tasks_repairing.unwrap_or_default());
+        self.nb_tasks_error_metric
+            .set(stats.nb_tasks_error.unwrap_or_default());
+        self.nb_tasks_stopping_metric
+            .set(stats.nb_tasks_stopping.unwrap_or_default());
+        self.nb_rss_items_unread_metric
+            .set(stats.nb_rss_items_unread.unwrap_or_default());
+        self.nb_peer_metric.set(stats.nb_peer.unwrap_or_default());
+
+        self.conn_ready_metric
+            .set(if stats.conn_ready.unwrap_or(false) { 1 } else { 0 });
+        self.throttling_is_scheduled_metric.set(
+            if stats.throttling_is_scheduled.unwrap_or(false) {
+                1
+            } else {
+                0
+            },
+        );
+
+        self.throttling_mode_metric.reset();
+        self.throttling_mode_metric
+            .with_label_values(&[stats.throttling_mode.as_deref().unwrap_or("unknown")])
+            .set(1);
+
+        let throttling_rate = stats.throttling_rate.unwrap_or(DlRate {
+            rx_rate: None,
+            tx_rate: None,
+        });
+        self.throttling_rx_rate_metric
+            .set(throttling_rate.rx_rate.unwrap_or_default());
+        self.throttling_tx_rate_metric
+            .set(throttling_rate.tx_rate.unwrap_or_default());
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<'a> MetricMap<'a> for DownloadMetricMap<'a> {
+    async fn init(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Ok(())
+    }
+
+    async fn set(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.set_download_metrics().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_deserialize_download_stats() {
+        let payload = r#"{
+            "nb_tasks": 13,
+            "nb_tasks_stopped": 1,
+            "nb_tasks_checking": 0,
+            "nb_tasks_queued": 0,
+            "nb_tasks_extracting": 4,
+            "nb_tasks_done": 1,
+            "nb_tasks_repairing": 0,
+            "nb_tasks_active": 11,
+            "nb_tasks_downloading": 4,
+            "nb_tasks_error": 0,
+            "nb_tasks_stopping": 0,
+            "nb_tasks_seeding": 3,
+            "nb_rss_items_unread": 5,
+            "rx_rate": 14222,
+            "tx_rate": 4294,
+            "throttling_mode": "normal",
+            "throttling_is_scheduled": true,
+            "throttling_rate": {
+                "rx_rate": 0,
+                "tx_rate": 0
+            },
+            "conn_ready": true,
+            "nb_peer": 42
+        }"#;
+
+        let stats: DownloadStats = serde_json::from_str(payload).unwrap();
+
+        assert_eq!(stats.nb_tasks.unwrap(), 13);
+        assert_eq!(stats.nb_tasks_stopped.unwrap(), 1);
+        assert_eq!(stats.nb_tasks_active.unwrap(), 11);
+        assert_eq!(stats.nb_tasks_downloading.unwrap(), 4);
+        assert_eq!(stats.nb_tasks_seeding.unwrap(), 3);
+        assert_eq!(stats.rx_rate.unwrap(), 14222);
+        assert_eq!(stats.tx_rate.unwrap(), 4294);
+        assert_eq!(stats.throttling_mode.unwrap(), "normal");
+        assert_eq!(stats.throttling_is_scheduled.unwrap(), true);
+        assert_eq!(stats.conn_ready.unwrap(), true);
+        assert_eq!(stats.nb_peer.unwrap(), 42);
+
+        let rate = stats.throttling_rate.unwrap();
+        assert_eq!(rate.rx_rate.unwrap(), 0);
+        assert_eq!(rate.tx_rate.unwrap(), 0);
+    }
+}

--- a/src/mappers/mod.rs
+++ b/src/mappers/mod.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use chrono::Duration;
 use connection::ConnectionMetricMap;
+use download::DownloadMetricMap;
 use lan::LanMetricMap;
 use lanbrowser::LanBrowserMetricMap;
 use log::{error, warn};
@@ -17,6 +18,7 @@ use crate::{
 };
 
 pub mod connection;
+pub mod download;
 pub mod dhcp;
 pub mod lan;
 pub mod lanbrowser;
@@ -166,6 +168,17 @@ impl<'a> Mapper<'a> {
             }
         } else {
             warn!("NAS metrics are disabled by default, missing entry in the configuration file");
+        }
+
+        if let Some(e) = conf.download {
+            if e {
+                maps.push(Box::new(DownloadMetricMap::new(
+                    factory,
+                    conf.prefix.to_owned().unwrap(),
+                )));
+            }
+        } else {
+            warn!("Download metrics are disabled by default, missing entry in the configuration file");
         }
 
         Self { maps }


### PR DESCRIPTION
This pull request adds support for exporting global downloader statistics from the Freebox OS Download API, allowing the exporter to expose various download-related metrics. It introduces a new configuration option, updates documentation and configuration files, and implements the logic for collecting and exposing these metrics.

**Download metrics support:**

* Added a new `download` configuration option to enable or disable the collection of global downloader statistics from the `/api/v4/downloads/stats` endpoint. This is reflected in the configuration struct, example config files, and documentation.

**Documentation updates:**

* Updated `README.md` to describe the new download metrics, configuration instructions, and examples of the exposed metrics.

**Implementation of metrics collection:**

* Implemented a new module `download.rs` that defines the `DownloadMetricMap` for collecting and exposing downloader statistics as Prometheus metrics, including traffic rates, task states, throttling, connection readiness, and peer counts. Includes deserialization, metric registration, and test coverage.
* Integrated the new `DownloadMetricMap` into the metrics mapping system, so that enabling the `download` option in the configuration will collect and expose these metrics.