### PR TITLE
Add documentation for the data directory in case the user use docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ unresolved_station_hostnames = "ignore"
 #   * "relabel" : Include stations with "unresolved" labels for missing host information
 
 [core]
-# Specify where to store data for exporter such as APP_TOKEN, logs, etc.
+# Specify where to store data for exporter such as APP_TOKEN, logs, etc. Set to "/data/" if you use docker, otherwise you will have to register the freebox-exporter-rs everytime you remake the container
 data_directory = "."
 # Specify which TCP port to listen to, for the /metrics HTTP endpoint
 port = 9102

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ unresolved_station_hostnames = "ignore"
 #   * "relabel" : Include stations with "unresolved" labels for missing host information
 
 [core]
-# Specify where to store data for exporter such as APP_TOKEN, logs, etc. Set to "/data/" if you use docker, otherwise you will have to register the freebox-exporter-rs everytime you remake the container
+# Specify where to store data for exporter such as APP_TOKEN, logs, etc. Set to "/data" if you use docker, otherwise you will have to register the freebox-exporter-rs everytime you remake the container
 data_directory = "."
 # Specify which TCP port to listen to, for the /metrics HTTP endpoint
 port = 9102


### PR DESCRIPTION
Using "." as a data directory when using docker means the token.dat file will be trashed everytime the container is restarted, meaning re-registration will be required everytime.

Moreover, currently a /data/ directory is made in the container but is not used for anything.

This seems like a documentation oversight, this PR fixes it.